### PR TITLE
新機能: ? キーでキーボードショートカット一覧、/ キーで検索フォーカス

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,7 @@ export default function App() {
   const [fontSize, setFontSize] = useState<FontSize>(loadFontSize);
   const [layout, setLayout] = useState<Layout>(loadLayout);
   const [mobilePane, setMobilePane] = useState<MobilePane>('sidebar');
+  const [showHelp, setShowHelp] = useState(false);
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
@@ -134,6 +135,16 @@ export default function App() {
     () => articles.filter((a) => bookmarkIds.has(a.id)).length,
     [articles, bookmarkIds],
   );
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (e.key === '?') setShowHelp((v) => !v);
+      if (e.key === 'Escape') setShowHelp(false);
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   useKeyboardNav({
     articles,
@@ -267,6 +278,48 @@ export default function App() {
       className="relative h-screen font-sans antialiased bg-surface-base text-text-strong lg:grid"
       style={{ gridTemplateColumns: '200px 360px 1fr', gridTemplateRows: '100%' }}
     >
+      {/* キーボードショートカット ヘルプ */}
+      {showHelp && (
+        <div
+          className="absolute inset-0 z-50 flex items-center justify-center bg-surface-base/80 backdrop-blur-sm"
+          onClick={() => setShowHelp(false)}
+        >
+          <div
+            className="bg-surface-elevated border border-border-default rounded-2xl shadow-[0_24px_64px_rgba(0,0,0,0.2)] p-6 w-72"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-4">
+              <span className="text-[10px] font-medium tracking-[0.25em] uppercase text-text-muted">キーボードショートカット</span>
+              <button
+                onClick={() => setShowHelp(false)}
+                className="text-text-faint hover:text-text-muted transition-colors"
+                aria-label="閉じる"
+              >
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+                  <path d="M2 2l10 10M12 2L2 12"/>
+                </svg>
+              </button>
+            </div>
+            <ul className="space-y-2">
+              {[
+                ['j / ↓', '次の記事'],
+                ['k / ↑', '前の記事'],
+                ['o', '元記事を開く'],
+                ['b', 'ブックマーク切替'],
+                ['r', '既読 / 未読切替'],
+                ['m', '全既読にする'],
+                ['/', '記事を検索'],
+                ['?', 'このヘルプを表示'],
+              ].map(([key, desc]) => (
+                <li key={key} className="flex items-center justify-between">
+                  <kbd className="text-[11px] font-mono px-1.5 py-0.5 rounded border border-border-default bg-surface-base text-text-muted">{key}</kbd>
+                  <span className="text-[12px] text-text-soft">{desc}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
       {newArticleCount > 0 && (
         <div className="absolute top-3 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 px-4 py-2 bg-ink text-ink-text text-[12px] tracking-[0.03em] rounded-full shadow-[0_4px_16px_rgba(0,0,0,0.2)] animate-fade-up">
           <span className="w-1.5 h-1.5 rounded-full bg-accent-dot flex-shrink-0" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,6 +104,15 @@ export default function App() {
     });
   }, [articles, bookmarkIds]);
 
+  const toggleRead = useCallback((articleId: string) => {
+    setReadIds((prev) => {
+      const next = new Set(prev);
+      next.has(articleId) ? next.delete(articleId) : next.add(articleId);
+      saveSet('rss-read', next);
+      return next;
+    });
+  }, []);
+
   const toggleBookmark = useCallback((articleId: string) => {
     setBookmarkIds((prev) => {
       const next = new Set(prev);
@@ -131,10 +140,12 @@ export default function App() {
     selectedFeedId,
     selectedArticle,
     bookmarkIds,
+    readIds,
     setSelectedArticle,
     markRead,
     markAllRead,
     toggleBookmark,
+    toggleRead,
   });
 
   // ローディング

--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useEffect, type ReactElement } from 'react';
+import { useState, useMemo, useEffect, useRef, type ReactElement } from 'react';
 import type { Article, Feed, Layout } from '../types';
 
 interface Props {
@@ -92,6 +92,19 @@ export default function ArticleList({
   const [unreadOnly, setUnreadOnly] = useState(false);
   const [query, setQuery] = useState('');
   const [page, setPage] = useState(1);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (e.key === '/') {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   const feedMap = useMemo(() => new Map(feeds.map((f) => [f.id, f.title || f.url])), [feeds]);
 
@@ -360,10 +373,14 @@ export default function ArticleList({
         </div>
         <div className="px-3 pb-2.5">
           <input
+            ref={searchRef}
             type="search"
-            placeholder="検索..."
+            placeholder="検索... (/ でフォーカス)"
             value={query}
             onChange={(e) => { setQuery(e.target.value); setPage(1); }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') { setQuery(''); setPage(1); searchRef.current?.blur(); }
+            }}
             className="w-full text-[12px] bg-surface-base border border-border-default rounded-lg px-2.5 py-1.5 text-text-strong placeholder-text-faint outline-none focus:border-text-muted transition-colors duration-200"
           />
         </div>

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -8,10 +8,12 @@ interface KeyboardNavOptions {
   selectedFeedId: string | null;
   selectedArticle: Article | null;
   bookmarkIds: Set<string>;
+  readIds: Set<string>;
   setSelectedArticle: (article: Article) => void;
   markRead: (id: string) => void;
   markAllRead: (feedId: string | null) => void;
   toggleBookmark: (id: string) => void;
+  toggleRead: (id: string) => void;
 }
 
 // キーボードナビゲーション: j/↓ 次の記事、k/↑ 前の記事、o 元記事を開く、b ブックマーク切り替え、m 全て既読
@@ -20,10 +22,12 @@ export function useKeyboardNav({
   selectedFeedId,
   selectedArticle,
   bookmarkIds,
+  readIds,
   setSelectedArticle,
   markRead,
   markAllRead,
   toggleBookmark,
+  toggleRead,
 }: KeyboardNavOptions): void {
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -46,11 +50,13 @@ export function useKeyboardNav({
         window.open(selectedArticle.link, '_blank', 'noopener,noreferrer');
       } else if (e.key === 'b' && selectedArticle) {
         toggleBookmark(selectedArticle.id);
+      } else if (e.key === 'r' && selectedArticle) {
+        toggleRead(selectedArticle.id);
       } else if (e.key === 'm') {
         markAllRead(selectedFeedId);
       }
     }
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [articles, selectedFeedId, selectedArticle, bookmarkIds, setSelectedArticle, markRead, markAllRead, toggleBookmark]);
+  }, [articles, selectedFeedId, selectedArticle, bookmarkIds, readIds, setSelectedArticle, markRead, markAllRead, toggleBookmark, toggleRead]);
 }


### PR DESCRIPTION
## Summary

- `?` キーを押すとキーボードショートカット一覧のヘルプモーダルを表示/非表示できるようにした
- `/` キーを押すと記事リストの検索インプットにフォーカスできるようにした
- `Escape` キーで検索クエリをクリアしてブラーする動作を追加

## Test plan

- [ ] ログイン後、`?` キーを押してヘルプモーダルが表示されることを確認
- [ ] モーダル外クリック / `Escape` / × ボタンで閉じることを確認
- [ ] `/` キーを押して検索ボックスにフォーカスされることを確認
- [ ] 検索中に `Escape` を押すとクエリがクリアされブラーすることを確認
- [ ] 入力フォームにフォーカス中は `?` / `/` が発火しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut help modal (press `?` to view available shortcuts)
  * Mark articles as read/unread using keyboard shortcuts
  * Focus search field with `/` keyboard shortcut
  * Escape key clears search queries and closes modals
  * Read article status now persists across sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->