### PR TITLE
リファクタ: 「さらに読み込む」ボタンを無限スクロールに置き換え

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import type { Article, Layout, FontSize } from './types';
 import { useAuth } from './hooks/useAuth';
 import { useFeeds } from './hooks/useFeeds';
 import { useKeyboardNav } from './hooks/useKeyboardNav';
+import { useFilteredArticles } from './hooks/useFilteredArticles';
 
 type Theme = 'light' | 'dark';
 type MobilePane = 'sidebar' | 'list' | 'view';
@@ -218,6 +219,18 @@ export default function App() {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, []);
 
+  const {
+    filtered,
+    visible,
+    hasMore,
+    unreadOnly,
+    toggleUnreadOnly,
+    query,
+    updateQuery,
+    searchRef,
+    sentinelRef,
+  } = useFilteredArticles({ articles, feedId: selectedFeedId, readIds, bookmarkIds });
+
   useKeyboardNav({
     articles,
     selectedFeedId,
@@ -234,6 +247,9 @@ export default function App() {
     onChangeFontSize,
     layout,
     onChangeLayout,
+    unreadOnly,
+    toggleUnreadOnly,
+    searchRef,
   });
 
   // ローディング
@@ -450,11 +466,8 @@ export default function App() {
       </div>
       <div className={`absolute inset-0 lg:relative lg:inset-auto overflow-hidden ${mobilePane !== 'list' ? 'hidden lg:block' : ''}`}>
         <ArticleList
-          articles={articles}
           feeds={feeds}
-          feedId={selectedFeedId}
           readIds={readIds}
-          bookmarkIds={bookmarkIds}
           selectedArticleId={selectedArticle?.id ?? null}
           layout={layout}
           loading={loadingArticles}
@@ -465,6 +478,15 @@ export default function App() {
             markRead(article.id);
             setMobilePane('view');
           }}
+          filtered={filtered}
+          visible={visible}
+          hasMore={hasMore}
+          unreadOnly={unreadOnly}
+          toggleUnreadOnly={toggleUnreadOnly}
+          query={query}
+          updateQuery={updateQuery}
+          searchRef={searchRef}
+          sentinelRef={sentinelRef}
         />
       </div>
       <div className={`absolute inset-0 lg:relative lg:inset-auto overflow-hidden ${mobilePane !== 'view' ? 'hidden lg:block' : ''}`}>

--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -1,21 +1,27 @@
 'use client';
 
-import { useMemo, useEffect, type ReactElement } from 'react';
+import { useMemo, useEffect, type ReactElement, type RefObject } from 'react';
 import type { Article, Feed, Layout } from '../types';
-import { useFilteredArticles } from '../hooks/useFilteredArticles';
 
 interface Props {
-  articles: Article[];
   feeds: Feed[];
-  feedId: string | null;
   readIds: Set<string>;
-  bookmarkIds: Set<string>;
   selectedArticleId: string | null;
   layout: Layout;
   loading?: boolean;
   onChangeLayout: (layout: Layout) => void;
   onSelectArticle: (article: Article) => void;
   onMobileBack?: () => void;
+  // useFilteredArticles からの状態（App.tsx で管理）
+  filtered: Article[];
+  visible: Article[];
+  hasMore: boolean;
+  unreadOnly: boolean;
+  toggleUnreadOnly: () => void;
+  query: string;
+  updateQuery: (q: string) => void;
+  searchRef: RefObject<HTMLInputElement | null>;
+  sentinelRef: RefObject<HTMLDivElement | null>;
 }
 
 /** ogImage がない場合、YouTube URL からサムネイルを生成 */
@@ -76,45 +82,24 @@ const LAYOUT_ICONS: Record<Layout, ReactElement> = {
 const LAYOUTS: Layout[] = ['compact', 'list', 'card', 'magazine'];
 
 export default function ArticleList({
-  articles,
   feeds,
-  feedId,
   readIds,
-  bookmarkIds,
   selectedArticleId,
   layout,
   loading = false,
   onChangeLayout,
   onSelectArticle,
   onMobileBack,
+  filtered,
+  visible,
+  hasMore,
+  unreadOnly,
+  toggleUnreadOnly,
+  query,
+  updateQuery,
+  searchRef,
+  sentinelRef,
 }: Props) {
-  const {
-    filtered,
-    visible,
-    hasMore,
-    unreadOnly,
-    toggleUnreadOnly,
-    query,
-    updateQuery,
-    searchRef,
-    sentinelRef,
-  } = useFilteredArticles({ articles, feedId, readIds, bookmarkIds });
-
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-      if (e.key === '/') {
-        e.preventDefault();
-        searchRef.current?.focus();
-      } else if (e.key === 'u') {
-        e.preventDefault();
-        toggleUnreadOnly();
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [searchRef, toggleUnreadOnly]);
-
   const feedMap = useMemo(() => new Map(feeds.map((f) => [f.id, f.title || f.url])), [feeds]);
 
   useEffect(() => {
@@ -376,7 +361,7 @@ export default function ArticleList({
       </div>
 
       <div className="flex-1 min-h-0 overflow-y-auto">
-        {loading && articles.length === 0 && (
+        {loading && filtered.length === 0 && (
           <div className="flex items-center justify-center h-40">
             <p className="text-[12px] text-text-faint">読み込み中...</p>
           </div>

--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useMemo, useEffect, useRef, useCallback, type ReactElement } from 'react';
+import { useMemo, useEffect, type ReactElement } from 'react';
 import type { Article, Feed, Layout } from '../types';
+import { useFilteredArticles } from '../hooks/useFilteredArticles';
 
 interface Props {
   articles: Article[];
@@ -38,8 +39,6 @@ function timeAgo(iso: string | null): string {
   if (days < 7) return `${days}日前`;
   return new Date(iso).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric' });
 }
-
-const PAGE_SIZE = 30;
 
 const LAYOUT_ICONS: Record<Layout, ReactElement> = {
   compact: (
@@ -89,11 +88,17 @@ export default function ArticleList({
   onSelectArticle,
   onMobileBack,
 }: Props) {
-  const [unreadOnly, setUnreadOnly] = useState(false);
-  const [query, setQuery] = useState('');
-  const [page, setPage] = useState(1);
-  const searchRef = useRef<HTMLInputElement>(null);
-  const sentinelRef = useRef<HTMLDivElement>(null);
+  const {
+    filtered,
+    visible,
+    hasMore,
+    unreadOnly,
+    toggleUnreadOnly,
+    query,
+    updateQuery,
+    searchRef,
+    sentinelRef,
+  } = useFilteredArticles({ articles, feedId, readIds, bookmarkIds });
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -103,18 +108,14 @@ export default function ArticleList({
         searchRef.current?.focus();
       } else if (e.key === 'u') {
         e.preventDefault();
-        setUnreadOnly((v) => !v);
-        setPage(1);
+        toggleUnreadOnly();
       }
     }
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, []);
+  }, [searchRef, toggleUnreadOnly]);
 
   const feedMap = useMemo(() => new Map(feeds.map((f) => [f.id, f.title || f.url])), [feeds]);
-
-  // フィード切り替え時にページをリセット
-  useEffect(() => { setPage(1); }, [feedId]);
 
   useEffect(() => {
     if (selectedArticleId) {
@@ -123,41 +124,6 @@ export default function ArticleList({
         ?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
     }
   }, [selectedArticleId]);
-
-  const loadMore = useCallback(() => {
-    setPage((p) => p + 1);
-  }, []);
-
-  useEffect(() => {
-    const el = sentinelRef.current;
-    if (!el) return;
-    const observer = new IntersectionObserver(
-      (entries) => { if (entries[0].isIntersecting) loadMore(); },
-      { rootMargin: '120px' },
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [loadMore]);
-
-  const filtered = useMemo(() => {
-    let list =
-      feedId === '__bookmarks__'
-        ? articles.filter((a) => bookmarkIds.has(a.id))
-        : feedId
-          ? articles.filter((a) => a.feedId === feedId)
-          : articles;
-    if (unreadOnly) list = list.filter((a) => !readIds.has(a.id));
-    if (query.trim()) {
-      const q = query.trim().toLowerCase();
-      list = list.filter(
-        (a) => a.title.toLowerCase().includes(q) || a.summary.toLowerCase().includes(q),
-      );
-    }
-    return list;
-  }, [articles, feedId, readIds, bookmarkIds, unreadOnly, query]);
-
-  const visible = filtered.slice(0, page * PAGE_SIZE);
-  const hasMore = visible.length < filtered.length;
 
   function handleSelect(article: Article) {
     onSelectArticle(article);
@@ -383,7 +349,7 @@ export default function ArticleList({
               ))}
             </div>
             <button
-              onClick={() => { setUnreadOnly((v) => !v); setPage(1); }}
+              onClick={toggleUnreadOnly}
               className={`text-[11px] tracking-[0.04em] px-2.5 py-0.5 rounded-full border transition-all duration-200 ${
                 unreadOnly
                   ? 'border-ink bg-ink text-ink-text'
@@ -400,9 +366,9 @@ export default function ArticleList({
             type="search"
             placeholder="検索... (/ でフォーカス)"
             value={query}
-            onChange={(e) => { setQuery(e.target.value); setPage(1); }}
+            onChange={(e) => updateQuery(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Escape') { setQuery(''); setPage(1); searchRef.current?.blur(); }
+              if (e.key === 'Escape') { updateQuery(''); searchRef.current?.blur(); }
             }}
             className="w-full text-[12px] bg-surface-base border border-border-default rounded-lg px-2.5 py-1.5 text-text-strong placeholder-text-faint outline-none focus:border-text-muted transition-colors duration-200"
           />

--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useEffect, useRef, type ReactElement } from 'react';
+import { useState, useMemo, useEffect, useRef, useCallback, type ReactElement } from 'react';
 import type { Article, Feed, Layout } from '../types';
 
 interface Props {
@@ -93,6 +93,7 @@ export default function ArticleList({
   const [query, setQuery] = useState('');
   const [page, setPage] = useState(1);
   const searchRef = useRef<HTMLInputElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -122,6 +123,21 @@ export default function ArticleList({
         ?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
     }
   }, [selectedArticleId]);
+
+  const loadMore = useCallback(() => {
+    setPage((p) => p + 1);
+  }, []);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => { if (entries[0].isIntersecting) loadMore(); },
+      { rootMargin: '120px' },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore]);
 
   const filtered = useMemo(() => {
     let list =
@@ -428,14 +444,7 @@ export default function ArticleList({
           </>
         )}
 
-        {hasMore && (
-          <button
-            onClick={() => setPage((p) => p + 1)}
-            className="w-full py-4 text-[11px] tracking-[0.08em] text-text-faint hover:text-text-soft transition-colors duration-200"
-          >
-            さらに読み込む ({filtered.length - visible.length})
-          </button>
-        )}
+        {hasMore && <div ref={sentinelRef} className="h-10" aria-hidden />}
       </div>
     </section>
   );

--- a/src/hooks/useFilteredArticles.ts
+++ b/src/hooks/useFilteredArticles.ts
@@ -1,0 +1,84 @@
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import type { Article } from '../types';
+
+const PAGE_SIZE = 30;
+
+interface Options {
+  articles: Article[];
+  feedId: string | null;
+  readIds: Set<string>;
+  bookmarkIds: Set<string>;
+}
+
+export function useFilteredArticles({ articles, feedId, readIds, bookmarkIds }: Options) {
+  const [unreadOnly, setUnreadOnly] = useState(false);
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  // フィード切り替え時にページ・検索クエリをリセット
+  useEffect(() => {
+    setPage(1);
+    setQuery('');
+  }, [feedId]);
+
+  const toggleUnreadOnly = useCallback(() => {
+    setUnreadOnly((v) => !v);
+    setPage(1);
+  }, []);
+
+  const updateQuery = useCallback((q: string) => {
+    setQuery(q);
+    setPage(1);
+  }, []);
+
+  const loadMore = useCallback(() => {
+    setPage((p) => p + 1);
+  }, []);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) loadMore();
+      },
+      { rootMargin: '120px' },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore]);
+
+  const filtered = useMemo(() => {
+    let list =
+      feedId === '__bookmarks__'
+        ? articles.filter((a) => bookmarkIds.has(a.id))
+        : feedId
+          ? articles.filter((a) => a.feedId === feedId)
+          : articles;
+    if (unreadOnly) list = list.filter((a) => !readIds.has(a.id));
+    if (query.trim()) {
+      const q = query.trim().toLowerCase();
+      list = list.filter(
+        (a) => a.title.toLowerCase().includes(q) || a.summary.toLowerCase().includes(q),
+      );
+    }
+    return list;
+  }, [articles, feedId, readIds, bookmarkIds, unreadOnly, query]);
+
+  const visible = filtered.slice(0, page * PAGE_SIZE);
+  const hasMore = visible.length < filtered.length;
+
+  return {
+    filtered,
+    visible,
+    hasMore,
+    unreadOnly,
+    toggleUnreadOnly,
+    query,
+    updateQuery,
+    searchRef,
+    sentinelRef,
+  };
+}

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, type RefObject } from 'react';
 import type { Article, FontSize, Layout } from '../types';
 
 interface KeyboardNavOptions {
@@ -19,9 +19,12 @@ interface KeyboardNavOptions {
   onChangeFontSize: (size: FontSize) => void;
   layout: Layout;
   onChangeLayout: (layout: Layout) => void;
+  unreadOnly: boolean;
+  toggleUnreadOnly: () => void;
+  searchRef: RefObject<HTMLInputElement | null>;
 }
 
-// キーボードナビゲーション: j/↓ 次の記事、k/↑ 前の記事、n/p 次/前の未読記事、o 元記事を開く、b ブックマーク切り替え、c リンクコピー、m 全て既読、l レイアウト切替
+// キーボードナビゲーション: j/↓ 次の記事、k/↑ 前の記事、n/p 次/前の未読記事、o 元記事を開く、b ブックマーク切り替え、c リンクコピー、m 全て既読、l レイアウト切替、u 未読フィルター切替、/ 検索フォーカス
 export function useKeyboardNav({
   articles,
   selectedFeedId,
@@ -38,6 +41,9 @@ export function useKeyboardNav({
   onChangeFontSize,
   layout,
   onChangeLayout,
+  unreadOnly,
+  toggleUnreadOnly,
+  searchRef,
 }: KeyboardNavOptions): void {
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -90,9 +96,16 @@ export function useKeyboardNav({
         onChangeLayout(next);
         const labels: Record<Layout, string> = { compact: 'コンパクト', list: 'リスト', card: 'カード', magazine: 'マガジン' };
         showToast(`レイアウト: ${labels[next]}`);
+      } else if (e.key === 'u') {
+        e.preventDefault();
+        toggleUnreadOnly();
+        showToast(!unreadOnly ? '未読フィルター: ON' : '未読フィルター: OFF');
+      } else if (e.key === '/') {
+        e.preventDefault();
+        searchRef.current?.focus();
       }
     }
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [articles, selectedFeedId, selectedArticle, bookmarkIds, readIds, setSelectedArticle, markRead, markAllRead, toggleBookmark, toggleRead, showToast, fontSize, onChangeFontSize, layout, onChangeLayout]);
+  }, [articles, selectedFeedId, selectedArticle, bookmarkIds, readIds, setSelectedArticle, markRead, markAllRead, toggleBookmark, toggleRead, showToast, fontSize, onChangeFontSize, layout, onChangeLayout, unreadOnly, toggleUnreadOnly, searchRef]);
 }


### PR DESCRIPTION
## Summary

- `ArticleList` の手動ページネーションボタン「さらに読み込む」を `IntersectionObserver` による自動無限スクロールに置き換え
- スクロール末尾に非表示センチネル `<div>` を配置し、viewport に入ったタイミングで次ページを自動ロード
- `rootMargin: '120px'` により、末尾に到達する直前に先読みが発動するため体感ラグがない

## Test plan

- [ ] 記事が 30 件超のフィードを選択し、スクロールで追加記事が自動ロードされることを確認
- [ ] フィード切り替え・検索・未読フィルター変更後にページがリセットされ、再スクロールで正しくロードされることを確認
- [ ] 全記事表示済み（`hasMore = false`）の場合、センチネルが DOM に存在しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Infinite scroll: articles load automatically as you scroll.
  * Keyboard shortcuts: "/" focuses search; "u" toggles unread-only and shows a toast.

* **Usability**
  * Search updates and Escape reliably reset/adjust results.
  * Unread toggle applies immediately without manual page resets.
  * Switching feeds resets search and pagination so feed content updates predictably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->