### PR TITLE
新機能: 記事のソート順切り替え

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -236,6 +236,8 @@ export default function App() {
     hasMore,
     unreadOnly,
     toggleUnreadOnly,
+    sortOrder,
+    toggleSortOrder,
     query,
     updateQuery,
     searchRef,
@@ -260,6 +262,8 @@ export default function App() {
     onChangeLayout,
     unreadOnly,
     toggleUnreadOnly,
+    sortOrder,
+    toggleSortOrder,
     searchRef,
   });
 
@@ -422,6 +426,7 @@ export default function App() {
                 ['r', '既読 / 未読切替'],
                 ['m', '全既読にする'],
                 ['u', '未読フィルター切替'],
+                ['s', 'ソート順切替'],
                 ['c', 'リンクをコピー'],
                 ['f', 'フォントサイズ切替'],
                 ['l', 'レイアウト切替'],
@@ -496,6 +501,8 @@ export default function App() {
           hasMore={hasMore}
           unreadOnly={unreadOnly}
           toggleUnreadOnly={toggleUnreadOnly}
+          sortOrder={sortOrder}
+          toggleSortOrder={toggleSortOrder}
           query={query}
           updateQuery={updateQuery}
           searchRef={searchRef}

--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useEffect, type ReactElement, type ReactNode, type RefObject } from 'react';
 import type { Article, Feed, Layout } from '../types';
+import type { SortOrder } from '../hooks/useFilteredArticles';
 
 interface Props {
   feeds: Feed[];
@@ -18,6 +19,8 @@ interface Props {
   hasMore: boolean;
   unreadOnly: boolean;
   toggleUnreadOnly: () => void;
+  sortOrder: SortOrder;
+  toggleSortOrder: () => void;
   query: string;
   updateQuery: (q: string) => void;
   searchRef: RefObject<HTMLInputElement | null>;
@@ -127,6 +130,8 @@ export default function ArticleList({
   hasMore,
   unreadOnly,
   toggleUnreadOnly,
+  sortOrder,
+  toggleSortOrder,
   query,
   updateQuery,
   searchRef,
@@ -374,6 +379,21 @@ export default function ArticleList({
               }`}
             >
               未読
+            </button>
+            <button
+              onClick={toggleSortOrder}
+              title={sortOrder === 'newest' ? '古い順に切り替え (s)' : '新しい順に切り替え (s)'}
+              className="w-6 h-6 flex items-center justify-center rounded text-text-faint hover:text-text-muted hover:bg-surface-subtle transition-all duration-200"
+            >
+              {sortOrder === 'newest' ? (
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M6 1v10M2 7l4 4 4-4"/>
+                </svg>
+              ) : (
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M6 11V1M2 5l4-4 4 4"/>
+                </svg>
+              )}
             </button>
           </div>
         </div>

--- a/src/hooks/useFilteredArticles.ts
+++ b/src/hooks/useFilteredArticles.ts
@@ -10,10 +10,13 @@ interface Options {
   bookmarkIds: Set<string>;
 }
 
+export type SortOrder = 'newest' | 'oldest';
+
 export function useFilteredArticles({ articles, feedId, readIds, bookmarkIds }: Options) {
   const [unreadOnly, setUnreadOnly] = useState(false);
   const [query, setQuery] = useState('');
   const [page, setPage] = useState(1);
+  const [sortOrder, setSortOrder] = useState<SortOrder>('newest');
   const searchRef = useRef<HTMLInputElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
@@ -30,6 +33,11 @@ export function useFilteredArticles({ articles, feedId, readIds, bookmarkIds }: 
 
   const updateQuery = useCallback((q: string) => {
     setQuery(q);
+    setPage(1);
+  }, []);
+
+  const toggleSortOrder = useCallback(() => {
+    setSortOrder((v) => (v === 'newest' ? 'oldest' : 'newest'));
     setPage(1);
   }, []);
 
@@ -64,8 +72,11 @@ export function useFilteredArticles({ articles, feedId, readIds, bookmarkIds }: 
         (a) => a.title.toLowerCase().includes(q) || a.summary.toLowerCase().includes(q),
       );
     }
+    if (sortOrder === 'oldest') {
+      list = [...list].reverse();
+    }
     return list;
-  }, [articles, feedId, readIds, bookmarkIds, unreadOnly, query]);
+  }, [articles, feedId, readIds, bookmarkIds, unreadOnly, query, sortOrder]);
 
   const visible = filtered.slice(0, page * PAGE_SIZE);
   const hasMore = visible.length < filtered.length;
@@ -76,6 +87,8 @@ export function useFilteredArticles({ articles, feedId, readIds, bookmarkIds }: 
     hasMore,
     unreadOnly,
     toggleUnreadOnly,
+    sortOrder,
+    toggleSortOrder,
     query,
     updateQuery,
     searchRef,

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, type RefObject } from 'react';
 import type { Article, FontSize, Layout } from '../types';
+import type { SortOrder } from './useFilteredArticles';
 
 interface KeyboardNavOptions {
   articles: Article[];
@@ -21,6 +22,8 @@ interface KeyboardNavOptions {
   onChangeLayout: (layout: Layout) => void;
   unreadOnly: boolean;
   toggleUnreadOnly: () => void;
+  sortOrder: SortOrder;
+  toggleSortOrder: () => void;
   searchRef: RefObject<HTMLInputElement | null>;
 }
 
@@ -43,6 +46,8 @@ export function useKeyboardNav({
   onChangeLayout,
   unreadOnly,
   toggleUnreadOnly,
+  sortOrder,
+  toggleSortOrder,
   searchRef,
 }: KeyboardNavOptions): void {
   useEffect(() => {
@@ -100,6 +105,9 @@ export function useKeyboardNav({
         e.preventDefault();
         toggleUnreadOnly();
         showToast(!unreadOnly ? '未読フィルター: ON' : '未読フィルター: OFF');
+      } else if (e.key === 's') {
+        toggleSortOrder();
+        showToast(sortOrder === 'newest' ? 'ソート: 古い順' : 'ソート: 新しい順');
       } else if (e.key === '/') {
         e.preventDefault();
         searchRef.current?.focus();
@@ -107,5 +115,5 @@ export function useKeyboardNav({
     }
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [articles, selectedFeedId, selectedArticle, bookmarkIds, readIds, setSelectedArticle, markRead, markAllRead, toggleBookmark, toggleRead, showToast, fontSize, onChangeFontSize, layout, onChangeLayout, unreadOnly, toggleUnreadOnly, searchRef]);
+  }, [articles, selectedFeedId, selectedArticle, bookmarkIds, readIds, setSelectedArticle, markRead, markAllRead, toggleBookmark, toggleRead, showToast, fontSize, onChangeFontSize, layout, onChangeLayout, unreadOnly, toggleUnreadOnly, sortOrder, toggleSortOrder, searchRef]);
 }


### PR DESCRIPTION
## Summary

- 記事一覧のソート順を新着順 / 古い順でトグル切り替えできる機能を追加
- `ArticleList` ヘッダーに矢印アイコンボタンを追加（現在の順序を示す）
- キーボードショートカット `s` キーでソート順をトグル、トースト通知で確認
- ヘルプモーダル（`?` キー）に `s` ショートカットの説明を追加

## Test plan

- [ ] 記事一覧ヘッダーのソートボタンをクリックして新着順 / 古い順が切り替わることを確認
- [ ] `s` キーでソート順がトグルされ、トースト通知が表示されることを確認
- [ ] `?` キーのヘルプモーダルに `s - ソート順切替` が表示されることを確認
- [ ] フィード切り替え時もソート順が保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sort order toggle to switch between newest and oldest articles
  * New sort button in the article list header with visual indicator for current sort direction
  * Keyboard shortcut 's' quickly toggles sort order with confirmation feedback displayed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->