### PR TITLE
リファクタリング: discoverFeedUrl を lib に抽出し、一般的パスプローブ機能を追加

### DIFF
--- a/app/api/feeds/route.ts
+++ b/app/api/feeds/route.ts
@@ -4,28 +4,10 @@ import { r2Get, r2Put } from '@/lib/r2';
 import { fetchArticles } from '@/cron/fetch';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { isValidFeedUrl } from '@/lib/url';
+import { discoverFeedUrl } from '@/lib/feed-discovery';
 import type { Feed } from '@/types';
 
 export const runtime = 'edge';
-
-/** HTML から RSS/Atom の URL を検出して返す。見つからなければ null */
-async function discoverFeedUrl(url: string): Promise<string | null> {
-  try {
-    const res = await fetch(url, { headers: { 'User-Agent': 'rss-reader/1.0' }, redirect: 'follow' });
-    if (!res.ok) return null;
-    const ct = res.headers.get('content-type') ?? '';
-    if (ct.includes('xml') || ct.includes('rss') || ct.includes('atom')) return url;
-    const html = await res.text();
-    const m =
-      html.match(/<link[^>]+rel=["']alternate["'][^>]+type=["']application\/(rss|atom)\+xml["'][^>]+href=["']([^"']+)["']/i) ??
-      html.match(/<link[^>]+type=["']application\/(rss|atom)\+xml["'][^>]+href=["']([^"']+)["']/i);
-    if (!m) return null;
-    const href = m[2];
-    return href.startsWith('http') ? href : new URL(href, url).toString();
-  } catch {
-    return null;
-  }
-}
 
 export async function GET() {
   const result = await requireSession();

--- a/src/lib/feed-discovery.ts
+++ b/src/lib/feed-discovery.ts
@@ -1,0 +1,109 @@
+/**
+ * RSS/Atom フィード URL を探索するユーティリティ。
+ *
+ * 探索順:
+ * 1. URL 自体が RSS/Atom (Content-Type で判定) → そのまま返す
+ * 2. HTML なら `<link rel="alternate" type="application/rss+xml">` タグを検索
+ * 3. 見つからなければ一般的なパス (/feed, /rss など) を並列プローブ
+ */
+
+/** 一般的な RSS/Atom フィードパス候補 */
+const COMMON_FEED_PATHS = [
+  '/feed',
+  '/rss',
+  '/rss.xml',
+  '/atom.xml',
+  '/feed.xml',
+  '/index.xml',
+  '/feeds/posts/default', // Blogger
+] as const;
+
+function isFeedContentType(ct: string): boolean {
+  return ct.includes('xml') || ct.includes('rss') || ct.includes('atom');
+}
+
+/**
+ * HTML から <link rel="alternate" type="application/rss+xml" href="..."> を検索する。
+ * type と href の属性順序は問わない。
+ */
+function extractFeedLinkFromHtml(html: string, baseUrl: string): string | null {
+  // type="..." が href="..." より前のパターン
+  const patternTypeFirst =
+    /<link[^>]+type=["']application\/(?:rss|atom)\+xml["'][^>]+href=["']([^"']+)["'][^>]*\/?>/gi;
+  // href="..." が type="..." より前のパターン
+  const patternHrefFirst =
+    /<link[^>]+href=["']([^"']+)["'][^>]+type=["']application\/(?:rss|atom)\+xml["'][^>]*\/?>/gi;
+
+  for (const pattern of [patternTypeFirst, patternHrefFirst]) {
+    pattern.lastIndex = 0;
+    const m = pattern.exec(html);
+    if (m?.[1]) {
+      try {
+        return new URL(m[1], baseUrl).toString();
+      } catch {
+        continue;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * サイトの origin に対して一般的なフィードパスを並列プローブし、
+ * 最初に見つかったフィード URL を返す。見つからなければ null。
+ */
+async function probeCommonFeedPaths(baseUrl: string): Promise<string | null> {
+  let origin: string;
+  try {
+    origin = new URL(baseUrl).origin;
+  } catch {
+    return null;
+  }
+
+  const results = await Promise.allSettled(
+    COMMON_FEED_PATHS.map(async (path) => {
+      const url = origin + path;
+      const res = await fetch(url, {
+        method: 'HEAD',
+        headers: { 'User-Agent': 'rss-reader/1.0' },
+        redirect: 'follow',
+      });
+      const ct = res.headers.get('content-type') ?? '';
+      if (res.ok && isFeedContentType(ct)) return url;
+      throw new Error('not a feed');
+    }),
+  );
+
+  for (const r of results) {
+    if (r.status === 'fulfilled') return r.value;
+  }
+  return null;
+}
+
+/**
+ * URL から RSS/Atom フィード URL を探索する。
+ *
+ * @param url 探索対象の URL（RSS 直リンク、またはサイトのトップページなど）
+ * @returns 発見したフィード URL。見つからない場合は null。
+ */
+export async function discoverFeedUrl(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': 'rss-reader/1.0' },
+      redirect: 'follow',
+    });
+    if (!res.ok) return null;
+
+    const ct = res.headers.get('content-type') ?? '';
+    if (isFeedContentType(ct)) return url;
+
+    const html = await res.text();
+
+    const fromLink = extractFeedLinkFromHtml(html, url);
+    if (fromLink) return fromLink;
+
+    return probeCommonFeedPaths(url);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- `app/api/feeds/route.ts` にインライン実装されていた `discoverFeedUrl` 関数を `src/lib/feed-discovery.ts` に抽出して再利用可能なライブラリとして整理
- `<link rel="alternate">` タグが見つからない場合に `/feed`、`/rss`、`/rss.xml`、`/atom.xml` などの一般的なパスを **並列** プローブする機能を追加（WordPress など `<link>` タグ非対応サイトへの対応）
- `type` と `href` の属性順序が逆のケースにも対応する正規表現に改善
- 相対 URL の解決を `new URL(href, baseUrl)` で統一（`href.startsWith('http')` 判定を廃止）

## Test plan

- [ ] RSS 直リンク（例: `https://example.com/feed.xml`）を入力してフィードが追加されることを確認
- [ ] サイト URL（例: `https://example.com`）を入力して `<link rel="alternate">` から自動検出されることを確認
- [ ] `<link>` タグがなく `/feed` にフィードがあるサイト（WordPress等）を入力して自動検出されることを確認
- [ ] `npm run typecheck` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced feed discovery mechanism with improved detection of RSS/Atom feeds, including support for common feed path detection as a fallback option for more reliable feed URL resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->