### PR TITLE
セキュリティ: Zenn ドメイン判定を URL パースに変更（includes バイパス修正）

### DIFF
--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -146,9 +146,17 @@ export function transformZennLinkEmbeds(content: string): string {
  * embed.zenn.studio/mermaid は親ページの Zenn スクリプト（postMessage）がないと
  * "Loading..." のまま表示されるため、data-content から直接ソースを取り出す。
  * zenn.dev のみ適用。他ドメイン（classmethod 等）では変換しない。
+ *
+ * 注意: includes() による部分文字列マッチは "zenn.dev.evil.com" でバイパスできるため、
+ * URL パースでホスト名を正確に検証する。
  */
 export function transformZennMermaidEmbeds(content: string, pageUrl = ''): string {
-  if (!pageUrl.includes('zenn.dev')) return content;
+  let isZennDev = false;
+  try {
+    const h = new URL(pageUrl).hostname;
+    isZennDev = h === 'zenn.dev' || h.endsWith('.zenn.dev');
+  } catch { /* ignore */ }
+  if (!isZennDev) return content;
   return content.replace(
     /<span\b[^>]*\bzenn-embedded-mermaid\b[^>]*>[\s\S]*?<\/span>/gi,
     (spanMatch) => {


### PR DESCRIPTION
## Summary

- `transformZennMermaidEmbeds` の `pageUrl.includes('zenn.dev')` を `new URL()` によるホスト名検証に変更
- `zenn.dev.evil.com` のようなドメインで mermaid 変換が誤作動するバイパスを修正
- `zenn.dev` または `*.zenn.dev` に完全一致する場合のみ変換を適用

## 影響範囲

- `src/lib/content.ts` の `transformZennMermaidEmbeds` 関数のみ
- 正規の zenn.dev 記事の動作は変わらない

## Test plan

- [x] `npm run typecheck` 通過
- [x] `node -e` でドメイン判定ロジックを手動検証（zenn.dev / sub.zenn.dev / zenn.dev.evil.com / notzenn.dev）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced hostname validation for improved reliability and security when processing content from specific domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->