### PR TITLE
修正: XML エンティティ展開上限を 1000 → 10000 に引き上げ

### DIFF
--- a/src/lib/xml-parser.ts
+++ b/src/lib/xml-parser.ts
@@ -76,8 +76,19 @@ const parser = new XMLParser({
   attributeNamePrefix: '@_',
   isArray: (name) => ['item', 'entry', 'link'].includes(name),
   // GHSA-jp2q-39xq-3w4g (entity 展開 DoS) は fast-xml-parser v4.2.4 以降で修正済み。
-  // v5.x では entity 展開制限が内部に組み込まれているため追加オプション不要。
-  processEntities: true,
+  // v5.x では processEntities オブジェクト形式で制限値を個別に設定できる。
+  //
+  // デフォルト maxTotalExpansions=1000 では HTML エンティティ（&amp; 等）を多用する
+  // フィード（例: 記事本文が長い技術ブログ）で "Entity expansion limit exceeded" が発生する。
+  // XMLボム攻撃（Billion Laughs）は maxExpansionDepth=10 と maxEntityCount=100 で防ぐ。
+  processEntities: {
+    enabled: true,
+    maxTotalExpansions: 10000,
+    maxEntitySize: 10000,
+    maxExpansionDepth: 10,
+    maxExpandedLength: 500000,
+    maxEntityCount: 100,
+  },
   htmlEntities: true,
 });
 


### PR DESCRIPTION
## Summary

- fast-xml-parser v5 の `processEntities: true`（デフォルト `maxTotalExpansions=1000`）では、HTML エンティティ（`&amp;` / `&lt;` 等）が多いフィードで `Entity expansion limit exceeded: 1572 > 1000` エラーが発生していた
- `processEntities` をオブジェクト形式に変更し、`maxTotalExpansions: 10000` に引き上げ
- XMLボム対策（`maxExpansionDepth: 10` / `maxEntityCount: 100`）は維持するためセキュリティへの影響なし

## 原因

技術ブログ等のフィードでは記事本文に大量の HTML エンティティが含まれる。
1 記事あたり数十個 × 30 記事 = 容易に 1000 超になる。

## Test plan

- [x] `npm run typecheck` 通過
- [x] 1500 エンティティを含む疑似フィードでパース成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)