### PR TITLE
新機能: Web Push 通知 — フィード更新時にブラウザ通知を送信

### DIFF
--- a/app/api/push/status/route.ts
+++ b/app/api/push/status/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { requireSession, applyRefreshedTokens } from '@/lib/server-auth';
+import { r2Get } from '@/lib/r2';
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import type { PushConfig } from '@/types';
+
+/** 現在のユーザーの Push 設定状態を返す */
+export async function GET() {
+  const result = await requireSession();
+  if ('error' in result) return result.error;
+  const { session } = result;
+  const { env } = await getCloudflareContext({ async: true });
+
+  const config = await r2Get<PushConfig>(
+    env.RSS_DATA,
+    `users/${session.userId}/push.json`,
+    { subscriptions: [] },
+  );
+
+  return applyRefreshedTokens(
+    NextResponse.json({ subscriptionCount: config.subscriptions.length }),
+    session,
+  );
+}

--- a/app/api/push/subscribe/route.ts
+++ b/app/api/push/subscribe/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { requireSession, applyRefreshedTokens } from '@/lib/server-auth';
+import { r2Get, r2Put } from '@/lib/r2';
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import type { PushConfig, PushSubscriptionRecord } from '@/types';
+
+/** Push サブスクリプションを R2 に保存する */
+export async function POST(request: Request) {
+  const result = await requireSession();
+  if ('error' in result) return result.error;
+  const { session } = result;
+  const { env } = await getCloudflareContext({ async: true });
+
+  const body = await request.json() as Partial<PushSubscriptionRecord>;
+
+  if (!body?.endpoint || !body?.keys?.p256dh || !body?.keys?.auth) {
+    return NextResponse.json({ error: 'Invalid subscription' }, { status: 400 });
+  }
+
+  const subscription: PushSubscriptionRecord = {
+    endpoint: body.endpoint,
+    expirationTime: body.expirationTime ?? null,
+    keys: { p256dh: body.keys.p256dh, auth: body.keys.auth },
+  };
+
+  const key = `users/${session.userId}/push.json`;
+  const config = await r2Get<PushConfig>(env.RSS_DATA, key, { subscriptions: [] });
+
+  // endpoint で重複排除して追加
+  config.subscriptions = config.subscriptions.filter((s) => s.endpoint !== subscription.endpoint);
+  config.subscriptions.push(subscription);
+
+  await r2Put(env.RSS_DATA, key, config);
+  return applyRefreshedTokens(NextResponse.json({ ok: true }), session);
+}

--- a/app/api/push/unsubscribe/route.ts
+++ b/app/api/push/unsubscribe/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { requireSession, applyRefreshedTokens } from '@/lib/server-auth';
+import { r2Get, r2Put } from '@/lib/r2';
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import type { PushConfig } from '@/types';
+
+/** Push サブスクリプションを R2 から削除する */
+export async function POST(request: Request) {
+  const result = await requireSession();
+  if ('error' in result) return result.error;
+  const { session } = result;
+  const { env } = await getCloudflareContext({ async: true });
+
+  const body = await request.json() as { endpoint?: string };
+  if (!body?.endpoint) {
+    return NextResponse.json({ error: 'endpoint is required' }, { status: 400 });
+  }
+
+  const key = `users/${session.userId}/push.json`;
+  const config = await r2Get<PushConfig>(env.RSS_DATA, key, { subscriptions: [] });
+
+  config.subscriptions = config.subscriptions.filter((s) => s.endpoint !== body.endpoint);
+  await r2Put(env.RSS_DATA, key, config);
+
+  return applyRefreshedTokens(NextResponse.json({ ok: true }), session);
+}

--- a/app/api/push/vapid-key/route.ts
+++ b/app/api/push/vapid-key/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { requireSession, applyRefreshedTokens } from '@/lib/server-auth';
+
+/** VAPID 公開鍵をクライアントに返す。Push 購読開始時に必要。 */
+export async function GET() {
+  const result = await requireSession();
+  if ('error' in result) return result.error;
+  const { session } = result;
+
+  const publicKey = process.env.VAPID_PUBLIC_KEY;
+  if (!publicKey) {
+    return NextResponse.json({ error: 'Push notifications not configured' }, { status: 503 });
+  }
+
+  return applyRefreshedTokens(NextResponse.json({ publicKey }), session);
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -88,3 +88,56 @@ self.addEventListener('fetch', (e) => {
       .catch(() => caches.match(e.request).then((cached) => cached ?? Response.error()))
   );
 });
+
+// -------------------------------------------------------------------------
+// Web Push 通知
+// -------------------------------------------------------------------------
+
+/** push イベント: サーバーからの通知を受け取り OS 通知を表示する */
+self.addEventListener('push', (e) => {
+  if (!e.data) return;
+
+  let data = { title: 'RSS Reader', body: '新着記事があります', url: '/' };
+  try {
+    data = { ...data, ...e.data.json() };
+  } catch {
+    // パース失敗時はデフォルト値を使用
+  }
+
+  e.waitUntil(
+    self.registration.showNotification(data.title, {
+      body: data.body,
+      icon: '/icon-192.png',
+      badge: '/icon-192.png',
+      // 同じタグで上書きすることで通知が積み重なることを防ぐ
+      tag: 'rss-new-articles',
+      renotify: true,
+      data: { url: data.url },
+    }),
+  );
+});
+
+/** notificationclick イベント: 通知クリックでアプリを開く */
+self.addEventListener('notificationclick', (e) => {
+  e.notification.close();
+  const url = e.notification.data?.url ?? '/';
+
+  e.waitUntil(
+    self.clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then((windowClients) => {
+        // 既存タブがあればフォーカス
+        for (const client of windowClients) {
+          try {
+            if (new URL(client.url).origin === self.location.origin) {
+              return client.focus();
+            }
+          } catch {
+            // URL パース失敗は無視
+          }
+        }
+        // なければ新規タブで開く
+        return self.clients.openWindow(url);
+      }),
+  );
+});

--- a/scripts/generate-vapid-keys.mjs
+++ b/scripts/generate-vapid-keys.mjs
@@ -1,0 +1,51 @@
+/**
+ * VAPID 鍵ペア生成スクリプト
+ *
+ * 使い方:
+ *   node scripts/generate-vapid-keys.mjs
+ *
+ * 出力された鍵を Cloudflare シークレットに登録:
+ *   npx wrangler secret put VAPID_PUBLIC_KEY
+ *   npx wrangler secret put VAPID_PRIVATE_KEY
+ *
+ * 公開鍵フォーマット: 65 バイト非圧縮 P-256 点 (0x04 || x || y) の base64url
+ * 秘密鍵フォーマット: 32 バイト P-256 スカラー の base64url
+ */
+
+import { webcrypto } from 'node:crypto';
+
+const { subtle } = webcrypto;
+
+// VAPID 用の ECDH P-256 鍵ペアを生成（ECDSA P-256 と同じ曲線）
+// ECDSA での署名に使うため、usage は ['sign'] + 'ECDSA' でも生成できるが
+// ここでは JWK 経由で raw バイトを取得するため ECDH で生成する
+const keyPair = await subtle.generateKey(
+  { name: 'ECDH', namedCurve: 'P-256' },
+  true, // エクスポート可能
+  ['deriveBits'],
+);
+
+// JWK 形式でエクスポート（x, y, d が base64url で得られる）
+const pubJwk = await subtle.exportKey('jwk', keyPair.publicKey);
+const privJwk = await subtle.exportKey('jwk', keyPair.privateKey);
+
+// 公開鍵: 65 バイト非圧縮点 (0x04 || x || y) を構築
+const x = Buffer.from(pubJwk.x, 'base64url');
+const y = Buffer.from(pubJwk.y, 'base64url');
+const uncompressed = Buffer.concat([Buffer.from([0x04]), x, y]);
+const pubBase64url = uncompressed.toString('base64url');
+
+// 秘密鍵: JWK の d フィールド (32 バイトスカラー) をそのまま使う
+const privBase64url = privJwk.d;
+
+console.log('=== VAPID 鍵ペア ===');
+console.log('');
+console.log('VAPID_PUBLIC_KEY (65 bytes uncompressed P-256):');
+console.log(pubBase64url);
+console.log('');
+console.log('VAPID_PRIVATE_KEY (32 bytes P-256 scalar):');
+console.log(privBase64url);
+console.log('');
+console.log('=== Cloudflare シークレット登録 ===');
+console.log('npx wrangler secret put VAPID_PUBLIC_KEY');
+console.log('npx wrangler secret put VAPID_PRIVATE_KEY');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import ArticleView from './components/ArticleView';
 import type { Feed, Article, Layout, FontSize } from './types';
 import { useAuth } from './hooks/useAuth';
 import { useFeeds } from './hooks/useFeeds';
+import { usePushNotifications } from './hooks/usePushNotifications';
 import { useKeyboardNav } from './hooks/useKeyboardNav';
 import { useFilteredArticles } from './hooks/useFilteredArticles';
 import { STORAGE_KEYS, storageGet, storageSet, loadSet, saveSet } from './lib/storage';
@@ -73,6 +74,7 @@ export default function App() {
 
   const { user, betaRestricted } = useAuth();
   const { feeds, articles, loadingArticles, refreshing, newArticleCount, onFeedAdded, removeFeed, updateFeed, replaceFeeds, refreshFeeds, retryFeed, dismissNewArticles } = useFeeds(user);
+  const { supported: pushSupported, subscribed: pushSubscribed, loading: pushLoading, toggle: togglePush } = usePushNotifications(user);
 
   const [readIds, setReadIds] = useState<Set<string>>(loadReadIds);
   const [bookmarkIds, setBookmarkIds] = useState<Set<string>>(loadBookmarkIds);
@@ -614,6 +616,10 @@ export default function App() {
           onTogglePinFeed={togglePinFeed}
           canInstall={!!installPrompt}
           onInstall={installApp}
+          pushSupported={pushSupported}
+          pushSubscribed={pushSubscribed}
+          pushLoading={pushLoading}
+          onTogglePush={togglePush}
         />
       </div>
       <div className={`absolute inset-0 lg:relative lg:inset-auto overflow-hidden ${mobilePane !== 'list' ? 'hidden lg:block' : ''}`}>

--- a/src/components/FeedSidebar.tsx
+++ b/src/components/FeedSidebar.tsx
@@ -167,6 +167,10 @@ interface Props {
   onTogglePinFeed: (id: string) => void;
   canInstall?: boolean;
   onInstall?: () => void;
+  pushSupported?: boolean;
+  pushSubscribed?: boolean;
+  pushLoading?: boolean;
+  onTogglePush?: () => void;
 }
 
 export default function FeedSidebar({
@@ -192,6 +196,10 @@ export default function FeedSidebar({
   onTogglePinFeed,
   canInstall,
   onInstall,
+  pushSupported,
+  pushSubscribed,
+  pushLoading,
+  onTogglePush,
 }: Props) {
   const [newUrl, setNewUrl] = useState('');
   const [adding, setAdding] = useState(false);
@@ -588,6 +596,24 @@ export default function FeedSidebar({
             <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M12 3v13.5m0 0l-4.5-4.5M12 16.5l4.5-4.5" />
             </svg>
+          </button>
+        )}
+        {pushSupported && (
+          <button
+            onClick={onTogglePush}
+            disabled={pushLoading}
+            className={`transition-colors duration-200 flex-shrink-0 ${pushSubscribed ? 'text-accent-dot' : 'text-text-faint hover:text-text-muted'} disabled:opacity-50`}
+            title={pushSubscribed ? 'プッシュ通知をオフ' : 'プッシュ通知をオン'}
+          >
+            {pushSubscribed ? (
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
+              </svg>
+            ) : (
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9.143 17.082a24.248 24.248 0 003.844.148m-3.844-.148a23.856 23.856 0 01-5.455-1.31 8.964 8.964 0 002.3-5.542m3.155 6.852a3 3 0 005.667 1.97m1.965-2.277L21 21m-4.225-4.225a23.81 23.81 0 003.536-1.003A8.967 8.967 0 0118 9.75V9A6 6 0 006.53 6.53m10.245 10.245L6.53 6.53M3 3l3.53 3.53" />
+              </svg>
+            )}
           </button>
         )}
         <button

--- a/src/cron/fetch.ts
+++ b/src/cron/fetch.ts
@@ -1,7 +1,8 @@
-import type { Feed, Article } from '../types';
+import type { Feed, Article, PushConfig } from '../types';
 
 import { parseFeed, type ParsedItem } from '../lib/xml-parser';
 import { isValidFeedUrl } from '../lib/url';
+import { sendPushToAll, type PushPayload } from '../lib/web-push';
 
 type FetchEnv = Pick<CloudflareEnv, 'RSS_DATA' | 'FINDME_RSS'>;
 import { r2Get, r2Put } from '../lib/r2';
@@ -187,10 +188,76 @@ async function fetchUserArticles(env: FetchEnv, userId: string, forceRetry = fal
     else void 0; // already logged above
   }
 
+  // 新着記事（既存 Map に存在しなかったもの）を検出
+  const newArticles = fresh.filter((a) => !existingByKey.has(articleKey(a.feedId, a.guid)));
+
   const merged = new Map<string, Article>(existingByKey);
   for (const a of fresh) merged.set(articleKey(a.feedId, a.guid), a);
 
   await r2Put(env.RSS_DATA, `users/${userId}/articles.json`, sortAndSlice(merged.values()));
+
+  // 新着記事がある場合は Push 通知を送信
+  if (newArticles.length > 0) {
+    await sendPushNotificationsForUser(env, userId, newArticles, feeds);
+  }
+}
+
+/**
+ * ユーザーの Push サブスクリプションに新着記事の通知を送る。
+ * 失効したサブスクリプション (404/410) は自動的に削除する。
+ */
+async function sendPushNotificationsForUser(
+  env: FetchEnv,
+  userId: string,
+  newArticles: Article[],
+  feeds: Feed[],
+): Promise<void> {
+  const pushKey = `users/${userId}/push.json`;
+  const config = await r2Get<PushConfig>(env.RSS_DATA, pushKey, { subscriptions: [] });
+  if (config.subscriptions.length === 0) return;
+
+  const payload = buildPushPayload(newArticles, feeds);
+  const remaining = await sendPushToAll(config.subscriptions, payload);
+
+  // 失効したサブスクリプションを除去して書き戻す
+  if (remaining.length !== config.subscriptions.length) {
+    config.subscriptions = remaining;
+    await r2Put(env.RSS_DATA, pushKey, config);
+  }
+}
+
+/** 新着記事リストから通知ペイロードを生成する */
+function buildPushPayload(newArticles: Article[], feeds: Feed[]): PushPayload {
+  const count = newArticles.length;
+
+  if (count === 1) {
+    const article = newArticles[0];
+    const feed = feeds.find((f) => f.id === article.feedId);
+    const feedName = feed?.title ?? 'RSS';
+    return {
+      title: feedName,
+      body: article.title || '新着記事',
+      url: '/',
+    };
+  }
+
+  // 全記事が同一フィードの場合
+  const feedIds = [...new Set(newArticles.map((a) => a.feedId))];
+  if (feedIds.length === 1) {
+    const feed = feeds.find((f) => f.id === feedIds[0]);
+    const feedName = feed?.title ?? 'RSS';
+    return {
+      title: feedName,
+      body: `${count} 件の新着記事`,
+      url: '/',
+    };
+  }
+
+  return {
+    title: 'RSS Reader',
+    body: `${count} 件の新着記事`,
+    url: '/',
+  };
 }
 
 // フィード追加・手動リフレッシュ時の即時フェッチ（エラー状態に関わらず強制再試行）

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import type { UserProfile } from '../types';
+
+export interface PushNotificationState {
+  /** ブラウザが Web Push をサポートしているか */
+  supported: boolean;
+  /** 現在のブラウザで購読中か */
+  subscribed: boolean;
+  /** 購読操作中か */
+  loading: boolean;
+  /** 購読/解除をトグルする */
+  toggle: () => Promise<void>;
+}
+
+export function usePushNotifications(user: UserProfile | null | undefined): PushNotificationState {
+  const [supported, setSupported] = useState(false);
+  const [subscribed, setSubscribed] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  // マウント時: ブラウザのサポート確認と現在の購読状態を取得
+  useEffect(() => {
+    if (!user) return;
+    if (typeof window === 'undefined') return;
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+
+    setSupported(true);
+
+    navigator.serviceWorker.ready
+      .then((reg) => reg.pushManager.getSubscription())
+      .then((sub) => setSubscribed(sub !== null))
+      .catch(() => {});
+  }, [user]);
+
+  const toggle = useCallback(async () => {
+    if (!supported || loading) return;
+    setLoading(true);
+
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const existing = await reg.pushManager.getSubscription();
+
+      if (existing) {
+        // 解除
+        await existing.unsubscribe();
+        await fetch('/api/push/unsubscribe', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ endpoint: existing.endpoint }),
+        });
+        setSubscribed(false);
+      } else {
+        // 購読
+        const permission = await Notification.requestPermission();
+        if (permission !== 'granted') return;
+
+        // VAPID 公開鍵を取得
+        const keyRes = await fetch('/api/push/vapid-key');
+        if (!keyRes.ok) return;
+        const { publicKey } = await keyRes.json() as { publicKey: string };
+
+        // base64url → Uint8Array に変換
+        const appServerKey = urlBase64ToUint8Array(publicKey);
+        const sub = await reg.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: appServerKey,
+        });
+
+        await fetch('/api/push/subscribe', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(sub.toJSON()),
+        });
+        setSubscribed(true);
+      }
+    } catch (err) {
+      console.error('Push toggle failed:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [supported, loading]);
+
+  return { supported, subscribed, loading, toggle };
+}
+
+/** base64url 文字列を Uint8Array に変換する（PushManager.subscribe の applicationServerKey 用） */
+function urlBase64ToUint8Array(base64url: string): Uint8Array<ArrayBuffer> {
+  const padding = '='.repeat((4 - (base64url.length % 4)) % 4);
+  const base64 = (base64url + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  const result = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) result[i] = raw.charCodeAt(i);
+  return result;
+}

--- a/src/lib/web-push.ts
+++ b/src/lib/web-push.ts
@@ -1,0 +1,291 @@
+/**
+ * Web Push 通知送信ライブラリ (Cloudflare Workers 対応)
+ *
+ * Node.js の web-push パッケージは Workers で動作しないため、
+ * crypto.subtle を使って VAPID 署名と RFC 8291 / aes128gcm 暗号化を実装する。
+ *
+ * 参照仕様:
+ * - RFC 8030: Generic Event Delivery Using HTTP Push
+ * - RFC 8292: Voluntary Application Server Identification (VAPID)
+ * - RFC 8291: Message Encryption for Web Push
+ * - RFC 8188: Encrypted Content-Encoding for HTTP
+ */
+
+import type { PushSubscriptionRecord } from '../types';
+
+// -------------------------------------------------------------------------
+// ユーティリティ
+// -------------------------------------------------------------------------
+
+function base64urlDecode(s: string): Uint8Array<ArrayBuffer> {
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64 + '==='.slice((b64.length + 3) % 4);
+  const binary = atob(padded);
+  const result = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) result[i] = binary.charCodeAt(i);
+  return result;
+}
+
+function base64urlEncode(buf: Uint8Array): string {
+  let binary = '';
+  for (const byte of buf) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function concatBytes(...arrays: Uint8Array<ArrayBufferLike>[]): Uint8Array<ArrayBuffer> {
+  const total = arrays.reduce((n, a) => n + a.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const a of arrays) {
+    out.set(a, offset);
+    offset += a.length;
+  }
+  return out;
+}
+
+/** テキストを UTF-8 バイト列にエンコード */
+const enc = new TextEncoder();
+
+// -------------------------------------------------------------------------
+// VAPID JWT 署名
+// -------------------------------------------------------------------------
+
+/**
+ * VAPID JWT を生成して Authorization ヘッダー文字列を返す。
+ *
+ * @param audience   push エンドポイントの origin (e.g. "https://fcm.googleapis.com")
+ * @param subject    mailto: または https: URI (管理者連絡先)
+ * @param publicKeyB64url  65 バイト非圧縮 P-256 点の base64url
+ * @param privateKeyB64url 32 バイト P-256 スカラーの base64url
+ */
+async function createVapidAuthHeader(
+  audience: string,
+  subject: string,
+  publicKeyB64url: string,
+  privateKeyB64url: string,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const exp = now + 12 * 60 * 60; // 12 時間
+
+  const header = base64urlEncode(enc.encode(JSON.stringify({ typ: 'JWT', alg: 'ES256' })));
+  const payload = base64urlEncode(
+    enc.encode(JSON.stringify({ aud: audience, exp, sub: subject })),
+  );
+  const signingInput = `${header}.${payload}`;
+
+  // P-256 秘密鍵をインポート（raw 32 バイト → JWK 経由）
+  const privRaw = base64urlDecode(privateKeyB64url);
+  const pubRaw = base64urlDecode(publicKeyB64url);
+  // JWK からインポート: x/y は公開鍵 (bytes 1-32, 33-64)、d は秘密鍵
+  const x = base64urlEncode(pubRaw.slice(1, 33));
+  const y = base64urlEncode(pubRaw.slice(33, 65));
+  const d = base64urlEncode(privRaw);
+
+  const privateKey = await crypto.subtle.importKey(
+    'jwk',
+    { kty: 'EC', crv: 'P-256', x, y, d, key_ops: ['sign'] },
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    false,
+    ['sign'],
+  );
+
+  const sig = await crypto.subtle.sign(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    privateKey,
+    enc.encode(signingInput),
+  );
+
+  const jwt = `${signingInput}.${base64urlEncode(new Uint8Array(sig))}`;
+  return `vapid t=${jwt}, k=${publicKeyB64url}`;
+}
+
+// -------------------------------------------------------------------------
+// RFC 8291 ペイロード暗号化 (aes128gcm content-encoding)
+// -------------------------------------------------------------------------
+
+/** HKDF-SHA256 で指定長のキーマテリアルを導出する */
+async function hkdfSha256(
+  ikm: Uint8Array<ArrayBuffer>,
+  salt: Uint8Array<ArrayBuffer>,
+  info: Uint8Array<ArrayBuffer>,
+  length: number,
+): Promise<Uint8Array<ArrayBuffer>> {
+  const baseKey = await crypto.subtle.importKey('raw', ikm, 'HKDF', false, ['deriveBits']);
+  const bits = await crypto.subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-256', salt, info },
+    baseKey,
+    length * 8,
+  );
+  return new Uint8Array(bits);
+}
+
+/**
+ * RFC 8291 準拠の aes128gcm 暗号化を実行する。
+ * 返値は aes128gcm エンコードされた完全なボディ（ヘッダー付き）。
+ */
+async function encryptPayload(
+  subscription: PushSubscriptionRecord,
+  plaintext: Uint8Array<ArrayBuffer>,
+): Promise<Uint8Array<ArrayBuffer>> {
+  // 乱数 salt (16 bytes) とエフェメラル鍵ペアを生成
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const serverKeyPair = await crypto.subtle.generateKey(
+    { name: 'ECDH', namedCurve: 'P-256' },
+    true,
+    ['deriveBits'],
+  );
+
+  // サーバーエフェメラル公開鍵 (65 bytes uncompressed) — slice() で ArrayBuffer を確保
+  const serverPubSpki = await crypto.subtle.exportKey('spki', serverKeyPair.publicKey);
+  const serverPubRaw = new Uint8Array(serverPubSpki).slice(-65);
+
+  // クライアント (受信者) の公開鍵をインポート
+  const clientPubRaw = base64urlDecode(subscription.keys.p256dh);
+  const clientPubKey = await crypto.subtle.importKey(
+    'raw',
+    clientPubRaw,
+    { name: 'ECDH', namedCurve: 'P-256' },
+    false,
+    [],
+  );
+
+  // ECDH 共有秘密 (32 bytes)
+  const ecdhBits = await crypto.subtle.deriveBits(
+    { name: 'ECDH', public: clientPubKey },
+    serverKeyPair.privateKey,
+    256,
+  );
+  const sharedSecret = new Uint8Array(ecdhBits);
+
+  // auth シークレット (16 bytes)
+  const authSecret = base64urlDecode(subscription.keys.auth);
+
+  // RFC 8291 Section 3.3: PRK の導出
+  // PRK_key = HKDF(auth_secret, ecdh_secret, "WebPush: info\0" || dh_pub || as_pub, 32)
+  const prk = await hkdfSha256(
+    sharedSecret,
+    authSecret,
+    concatBytes(enc.encode('WebPush: info\0'), clientPubRaw, serverPubRaw),
+    32,
+  );
+
+  // CEK (16 bytes) の導出
+  const cek = await hkdfSha256(
+    prk,
+    salt,
+    enc.encode('Content-Encoding: aes128gcm\0'),
+    16,
+  );
+
+  // nonce (12 bytes) の導出
+  const nonce = await hkdfSha256(
+    prk,
+    salt,
+    enc.encode('Content-Encoding: nonce\0'),
+    12,
+  );
+
+  // AES-128-GCM 暗号化 (padding delimiter 0x02 を末尾に追加)
+  const paddedPlaintext = concatBytes(plaintext, new Uint8Array([0x02]));
+  const cekKey = await crypto.subtle.importKey('raw', cek, 'AES-GCM', false, ['encrypt']);
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: nonce, tagLength: 128 },
+    cekKey,
+    paddedPlaintext,
+  );
+
+  // aes128gcm コンテンツエンコーディングヘッダーを構築
+  // salt (16) + rs (4, big-endian) + idlen (1) + keyid (65)
+  const rs = 4096; // レコードサイズ
+  const header = new Uint8Array(16 + 4 + 1 + 65);
+  header.set(salt, 0);
+  const rsView = new DataView(header.buffer, 16, 4);
+  rsView.setUint32(0, rs, false); // big-endian
+  header[20] = 65; // idlen
+  header.set(serverPubRaw, 21);
+
+  return concatBytes(header, new Uint8Array(ciphertext));
+}
+
+// -------------------------------------------------------------------------
+// 公開 API
+// -------------------------------------------------------------------------
+
+export interface PushPayload {
+  title: string;
+  body: string;
+  url: string;
+}
+
+export interface PushResult {
+  ok: boolean;
+  /** true = 404/410 → サブスクリプションを削除すべき */
+  gone: boolean;
+}
+
+/**
+ * 1 件のサブスクリプションに Web Push 通知を送信する。
+ *
+ * VAPID 鍵は process.env.VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY から読む。
+ * VAPID_SUBJECT は wrangler.toml の [vars] から読む (process.env.VAPID_SUBJECT)。
+ */
+export async function sendPush(
+  subscription: PushSubscriptionRecord,
+  payload: PushPayload,
+): Promise<PushResult> {
+  const publicKey = process.env.VAPID_PUBLIC_KEY;
+  const privateKey = process.env.VAPID_PRIVATE_KEY;
+  const subject = process.env.VAPID_SUBJECT ?? 'mailto:admin@example.com';
+
+  // VAPID 未設定時はスキップ（ローカル開発環境等）
+  if (!publicKey || !privateKey) return { ok: false, gone: false };
+
+  const audience = new URL(subscription.endpoint).origin;
+  const authHeader = await createVapidAuthHeader(audience, subject, publicKey, privateKey);
+
+  const body = encryptPayload(subscription, enc.encode(JSON.stringify(payload)));
+  const encryptedBody = await body;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10_000);
+
+  let res: Response;
+  try {
+    res = await fetch(subscription.endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: authHeader,
+        'Content-Type': 'application/octet-stream',
+        'Content-Encoding': 'aes128gcm',
+        TTL: '86400',
+      },
+      body: encryptedBody.buffer,
+      signal: controller.signal,
+    });
+  } catch {
+    return { ok: false, gone: false };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  // 404 / 410 = サブスクリプション失効
+  if (res.status === 404 || res.status === 410) return { ok: false, gone: true };
+  return { ok: res.ok, gone: false };
+}
+
+/**
+ * ユーザーの全サブスクリプションに送信し、失効分を除外したリストを返す。
+ */
+export async function sendPushToAll(
+  subscriptions: PushSubscriptionRecord[],
+  payload: PushPayload,
+): Promise<PushSubscriptionRecord[]> {
+  const results = await Promise.allSettled(
+    subscriptions.map((sub) => sendPush(sub, payload)),
+  );
+
+  return subscriptions.filter((_, i) => {
+    const r = results[i];
+    return r.status === 'rejected' || !r.value.gone;
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,21 @@ export interface UserProfile {
   picture: string | null;
 }
 
+/** Web Push サブスクリプション（PushSubscription.toJSON() の表現） */
+export interface PushSubscriptionRecord {
+  endpoint: string;
+  expirationTime: number | null;
+  keys: {
+    p256dh: string; // base64url — ユーザーエージェントの公開鍵 (65 bytes uncompressed P-256)
+    auth: string;   // base64url — 認証シークレット (16 bytes)
+  };
+}
+
+/** R2 に保存するユーザーの Push 通知設定 */
+export interface PushConfig {
+  subscriptions: PushSubscriptionRecord[];
+}
+
 export interface Env {
   RSS_DATA: R2Bucket;
   AI: Ai;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -27,6 +27,7 @@ AUTH_BASE_URL = "https://id.0g0.xyz"
 APP_BASE_URL = "https://rss.0g0.xyz"
 # ベータアクセス制限: 許可する sub をカンマ区切りで列挙。空文字なら制限なし
 BETA_ALLOWED_SUBS = "551a6605-2ca0-4196-b823-5676dbd585a3"
+VAPID_SUBJECT = "mailto:admin@0g0.xyz"
 # Cloudflare AI toMarkdown API (全文取得フォールバック用)
 # CLOUDFLARE_API_TOKEN は `npx wrangler secret put CLOUDFLARE_API_TOKEN` で設定
 
@@ -57,3 +58,7 @@ invocation_logs = true
 # シークレットは以下で設定:
 # npx wrangler secret put CLIENT_ID
 # npx wrangler secret put CLIENT_SECRET
+#
+# Push 通知用 VAPID 鍵 (node scripts/generate-vapid-keys.mjs で生成):
+# npx wrangler secret put VAPID_PUBLIC_KEY
+# npx wrangler secret put VAPID_PRIVATE_KEY


### PR DESCRIPTION
## Summary

- Cloudflare Workers 対応の Web Push 実装（`crypto.subtle` で VAPID + RFC 8291 暗号化）
- Push 購読管理 API を 4 本追加（vapid-key / subscribe / unsubscribe / status）
- Service Worker に push/notificationclick ハンドラーを追加
- `usePushNotifications` フック + FeedSidebar ベルアイコンボタン
- クロン実行時に新着記事を検知して全サブスクリプションへ通知送信

## 有効化手順

```bash
node scripts/generate-vapid-keys.mjs
npx wrangler secret put VAPID_PUBLIC_KEY
npx wrangler secret put VAPID_PRIVATE_KEY
```

## Test plan

- [ ] `node scripts/generate-vapid-keys.mjs` で鍵ペアが出力される
- [ ] `npm run typecheck` 通過
- [ ] ブラウザで通知許可 → DevTools Application > Push で手動テスト
- [ ] ベルアイコンをトグル → 購読/解除が R2 に反映される
- [ ] 404/410 の失効エンドポイントが自動削除される

🤖 Generated with [Claude Code](https://claude.com/claude-code)