### PR TITLE
修正: 記事詳細でカードと同じOG画像を表示

### DIFF
--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -75,6 +75,8 @@ export default function ArticleView({ article, isBookmarked, onToggleBookmark, i
   const [fetchedContent, setFetchedContent] = useState<string | null>(null);
   const [fetching, setFetching] = useState(false);
   const [fetchError, setFetchError] = useState('');
+  // article.ogImage がない場合に /api/ogp から動的に解決した画像URL
+  const [resolvedOgImage, setResolvedOgImage] = useState<string | null>(null);
   const [aiResult, setAiResult] = useState<{ mode: AiMode; text: string } | null>(null);
   const [aiLoading, setAiLoading] = useState<AiMode | null>(null);
   const [scrollProgress, setScrollProgress] = useState(0);
@@ -152,6 +154,16 @@ export default function ArticleView({ article, isBookmarked, onToggleBookmark, i
       setFetching(false);
     }
   }, [article?.link, article?.id, doRunAi]);
+
+  // article.ogImage がない場合に /api/ogp からサムネイルを解決する
+  useEffect(() => {
+    setResolvedOgImage(null);
+    if (!article?.link || article.ogImage) return;
+    fetch(`/api/ogp?url=${encodeURIComponent(article.link)}`)
+      .then((r) => r.json() as Promise<{ image?: string }>)
+      .then(({ image }) => { if (image) setResolvedOgImage(image); })
+      .catch(() => {});
+  }, [article?.id, article?.link, article?.ogImage]);
 
   // 記事が変わったらリセット → sticky モードが設定済みなら自動実行
   // 全文取得が必要な場合は取得後に AI 実行
@@ -452,10 +464,10 @@ export default function ArticleView({ article, isBookmarked, onToggleBookmark, i
           </div>
         )}
 
-        {/* OGP 画像 (埋め込みなし・全文未取得時) */}
-        {!embedInfo && article.ogImage && (
+        {/* OGP 画像 (埋め込みなし) */}
+        {!embedInfo && (article.ogImage ?? resolvedOgImage) && (
           <img
-            src={`/api/image-proxy?url=${encodeURIComponent(article.ogImage)}`}
+            src={`/api/image-proxy?url=${encodeURIComponent((article.ogImage ?? resolvedOgImage)!)}`}
             alt=""
             className="w-full rounded-lg object-contain bg-surface-subtle mb-6 aspect-video"
             loading="lazy"


### PR DESCRIPTION
## Summary

- `article.ogImage` がない記事でも `/api/ogp` から動的にサムネイルを解決して `ArticleView` に表示
- `ArticleList` の `ogpCache` ロジックと同じアプローチを `ArticleView` 内に実装
- カード一覧と記事詳細で画像表示が一致するようになった

## Test plan

- [ ] `article.ogImage` が null の記事（例: ITmedia）をクリック → 詳細画面に画像が表示される
- [ ] `article.ogImage` がある記事は従来通り即時表示される
- [ ] `/api/ogp` が失敗しても画像なしで正常表示される（エラー無視）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Articles now automatically resolve and display thumbnail images when missing. This enhancement ensures consistent visual presentation across all article previews, with graceful error handling to maintain a seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->