### PR TITLE
修正: 全APIルートでトークンリフレッシュを確実に伝播

### DIFF
--- a/app/api/ai/summarize/route.ts
+++ b/app/api/ai/summarize/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { requireSession } from '@/lib/server-auth';
+import { requireSession, applyRefreshedTokens } from '@/lib/server-auth';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { getAiCache, setAiCache } from '@/lib/ai-cache';
 import { toPlainText } from '@/lib/html';
@@ -10,16 +10,17 @@ const MODEL = '@cf/meta/llama-3.1-8b-instruct' as any;
 export async function POST(request: Request) {
   const result = await requireSession();
   if ('error' in result) return result.error;
+  const { session } = result;
 
   const { text } = await request.json() as { text?: string };
-  if (!text?.trim()) return NextResponse.json({ error: 'text is required' }, { status: 400 });
+  if (!text?.trim()) return applyRefreshedTokens(NextResponse.json({ error: 'text is required' }, { status: 400 }), session);
 
   const { env } = await getCloudflareContext({ async: true });
   const plain = toPlainText(text).slice(0, 6000);
 
   // キャッシュヒット
   const cached = await getAiCache(env.RSS_DATA, 'summary', plain);
-  if (cached) return NextResponse.json({ result: cached });
+  if (cached) return applyRefreshedTokens(NextResponse.json({ result: cached }), session);
 
   // AI 実行
   const response = await env.AI.run(MODEL, {
@@ -33,5 +34,5 @@ export async function POST(request: Request) {
 
   if (summary) await setAiCache(env.RSS_DATA, 'summary', plain, summary);
 
-  return NextResponse.json({ result: summary });
+  return applyRefreshedTokens(NextResponse.json({ result: summary }), session);
 }

--- a/app/api/ai/translate/route.ts
+++ b/app/api/ai/translate/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { requireSession } from '@/lib/server-auth';
+import { requireSession, applyRefreshedTokens } from '@/lib/server-auth';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { getAiCache, setAiCache } from '@/lib/ai-cache';
 import { toPlainText } from '@/lib/html';
@@ -10,16 +10,17 @@ const MODEL = '@cf/meta/llama-3.1-8b-instruct' as any;
 export async function POST(request: Request) {
   const result = await requireSession();
   if ('error' in result) return result.error;
+  const { session } = result;
 
   const { text } = await request.json() as { text?: string };
-  if (!text?.trim()) return NextResponse.json({ error: 'text is required' }, { status: 400 });
+  if (!text?.trim()) return applyRefreshedTokens(NextResponse.json({ error: 'text is required' }, { status: 400 }), session);
 
   const { env } = await getCloudflareContext({ async: true });
   const plain = toPlainText(text).slice(0, 6000);
 
   // キャッシュヒット
   const cached = await getAiCache(env.RSS_DATA, 'translation', plain);
-  if (cached) return NextResponse.json({ result: cached });
+  if (cached) return applyRefreshedTokens(NextResponse.json({ result: cached }), session);
 
   // AI 実行
   const response = await env.AI.run(MODEL, {
@@ -33,5 +34,5 @@ export async function POST(request: Request) {
 
   if (translation) await setAiCache(env.RSS_DATA, 'translation', plain, translation);
 
-  return NextResponse.json({ result: translation });
+  return applyRefreshedTokens(NextResponse.json({ result: translation }), session);
 }

--- a/app/api/content/route.ts
+++ b/app/api/content/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { requireSession } from '@/lib/server-auth';
+import { requireSession, applyRefreshedTokens } from '@/lib/server-auth';
 import { isValidFeedUrl } from '@/lib/url';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { sha256Hex } from '@/lib/r2';
@@ -20,7 +20,11 @@ const MAX_CONTENT_BYTES = 5 * 1024 * 1024;
 export async function GET(request: Request) {
   const result = await requireSession();
   if ('error' in result) return result.error;
+  const { session } = result;
+  return applyRefreshedTokens(await handleGet(request), session);
+}
 
+async function handleGet(request: Request): Promise<NextResponse> {
   const url = new URL(request.url).searchParams.get('url');
   if (!url) return NextResponse.json({ error: 'url is required' }, { status: 400 });
 
@@ -105,3 +109,4 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Failed to fetch page' }, { status: 502 });
   }
 }
+

--- a/app/api/feeds/export/route.ts
+++ b/app/api/feeds/export/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { requireSession } from '@/lib/server-auth';
+import { requireSession, applyRefreshedTokens } from '@/lib/server-auth';
 import { r2Get } from '@/lib/r2';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import type { Feed } from '@/types';
@@ -36,10 +36,10 @@ export async function GET() {
   const feeds = await r2Get<Feed[]>(env.RSS_DATA, `users/${session.userId}/feeds.json`, []);
   const opml = buildOpml(feeds);
 
-  return new NextResponse(opml, {
+  return applyRefreshedTokens(new NextResponse(opml, {
     headers: {
       'Content-Type': 'text/xml; charset=utf-8',
       'Content-Disposition': 'attachment; filename="feeds.opml"',
     },
-  });
+  }), session);
 }

--- a/app/api/image-proxy/route.ts
+++ b/app/api/image-proxy/route.ts
@@ -1,4 +1,4 @@
-import { requireSession } from '@/lib/server-auth';
+import { requireSession, applyRefreshedTokensToResponse } from '@/lib/server-auth';
 import { isValidFeedUrl } from '@/lib/url';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { sha256Hex } from '@/lib/r2';
@@ -33,7 +33,11 @@ function transparentGif(): Response {
 export async function GET(request: Request) {
   const result = await requireSession();
   if ('error' in result) return result.error;
+  const { session } = result;
+  return applyRefreshedTokensToResponse(await handleGet(request), session);
+}
 
+async function handleGet(request: Request): Promise<Response> {
   const url = new URL(request.url).searchParams.get('url');
   if (!url) return new Response(null, { status: 400 });
 
@@ -123,3 +127,4 @@ export async function GET(request: Request) {
     return transparentGif();
   }
 }
+

--- a/app/api/ogp/route.ts
+++ b/app/api/ogp/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { requireSession } from '@/lib/server-auth';
+import { requireSession, applyRefreshedTokens } from '@/lib/server-auth';
 import { isValidFeedUrl } from '@/lib/url';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { sha256Hex } from '@/lib/r2';
@@ -13,7 +13,11 @@ const OGP_CACHE_TTL_SEC = 30 * 24 * 60 * 60; // 30日
 export async function GET(request: Request) {
   const result = await requireSession();
   if ('error' in result) return result.error;
+  const { session } = result;
+  return applyRefreshedTokens(await handleGet(request), session);
+}
 
+async function handleGet(request: Request): Promise<NextResponse> {
   const url = new URL(request.url).searchParams.get('url');
   if (!url) return NextResponse.json({ image: '' });
   if (!isValidFeedUrl(url)) return NextResponse.json({ image: '' });
@@ -88,3 +92,4 @@ export async function GET(request: Request) {
     return NextResponse.json({ image: '' });
   }
 }
+

--- a/src/lib/server-auth.ts
+++ b/src/lib/server-auth.ts
@@ -63,7 +63,7 @@ export async function requireSession(): Promise<{ session: AuthSession } | { err
   return { session };
 }
 
-/** リフレッシュされたトークンがある場合に Response に cookie をセットする */
+/** リフレッシュされたトークンがある場合に NextResponse に cookie をセットする */
 export function applyRefreshedTokens(
   response: NextResponse,
   session: AuthSession,
@@ -73,4 +73,20 @@ export function applyRefreshedTokens(
     response.cookies.set('refresh_token', session.refreshedTokens.refresh_token, { ...COOKIE_OPTS, maxAge: 30 * 24 * 60 * 60 });
   }
   return response;
+}
+
+/**
+ * バイナリレスポンス（Response）にもリフレッシュ済みトークン Cookie をセットする。
+ * image-proxy など NextResponse を使わないエンドポイント用。
+ */
+export function applyRefreshedTokensToResponse(
+  response: Response,
+  session: AuthSession,
+): Response {
+  if (!session.refreshedTokens) return response;
+  const cookiePath = `; Path=/; HttpOnly; Secure; SameSite=Lax`;
+  const headers = new Headers(response.headers);
+  headers.append('Set-Cookie', `access_token=${session.refreshedTokens.access_token}; Max-Age=900${cookiePath}`);
+  headers.append('Set-Cookie', `refresh_token=${session.refreshedTokens.refresh_token}; Max-Age=${30 * 24 * 60 * 60}${cookiePath}`);
+  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
 }


### PR DESCRIPTION
## Summary

- アクセストークン期限切れ時にリフレッシュが成功しても、6つのAPIルートで `applyRefreshedTokens` が未呼び出しだったため新トークンがブラウザに届かない問題を修正
- リフレッシュトークンが使い捨ての場合、次リクエストでリフレッシュ失敗→ログアウトになる恐れがあった

## 変更内容

| ルート | 対応 |
|---|---|
| `ai/summarize`, `ai/translate` | 全返却パスに `applyRefreshedTokens` を追加 |
| `feeds/export` | 成功レスポンスに `applyRefreshedTokens` を追加 |
| `content`, `ogp` | `handleGet()` 内部関数に分離して `GET()` で一括適用 |
| `image-proxy` | `Response` 用の `applyRefreshedTokensToResponse` を追加して適用 |

## Test plan

- [ ] `npm run typecheck` 通過
- [ ] アクセストークン期限切れ状態で AI 要約/翻訳を実行 → 新トークンが Cookie にセットされる
- [ ] ログアウトせずに操作が継続できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored multiple API endpoints to implement consistent session token refresh handling mechanisms, improving system reliability and ensuring proper authentication across all requests and responses.

* **Chores**
  * Enhanced underlying authentication infrastructure and token lifecycle management to provide stronger, more reliable session security across all platform services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->