### PR TITLE
セキュリティ修正: transformZennLinkEmbeds で URL を HTML エスケープして XSS を防止

### DIFF
--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -133,7 +133,13 @@ export function transformZennLinkEmbeds(content: string): string {
         const url = decodeURIComponent(dcMatch[1]);
         // javascript: / data: 等の危険スキームをブロック（XSS 防止）
         if (!/^https?:\/\//i.test(url)) return spanMatch;
-        return `<p><a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a></p>`;
+        // URL に " < > & が含まれる場合にHTML属性から脱出されないようHTMLエスケープ
+        const escaped = url
+          .replace(/&/g, '&amp;')
+          .replace(/"/g, '&quot;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;');
+        return `<p><a href="${escaped}" target="_blank" rel="noopener noreferrer">${escaped}</a></p>`;
       } catch {
         return spanMatch;
       }


### PR DESCRIPTION
## Summary

- `transformZennLinkEmbeds` で `data-content` からデコードした URL を `href` 属性に挿入する際、HTML エスケープが欠落していた
- URL に `"` が含まれる場合、属性境界を脱出して `onclick` 等のイベントハンドラを注入できる XSS 脆弱性が存在した
- `sanitizeHtml` の正規表現 `/[\s\/]+on\w+\s*=/` は `"onclick=` パターン（ダブルクォートの直後）を検出できないため、末端のサニタイズに頼れなかった

## 再現手順

```
data-content="https%3A%2F%2Fexample.com%2F%22onclick%3D%22alert(1)"
```

デコード後: `https://example.com/"onclick="alert(1)`

修正前の出力:
```html
<a href="https://example.com/"onclick="alert(1)" ...>
```

修正後の出力:
```html
<a href="https://example.com/&quot;onclick=&quot;alert(1)" ...>
```

## Test plan

- [ ] `npm run typecheck` が通ること
- [ ] 通常の Zenn embed URL（`https://zenn.dev/...`）が正しくリンクに変換されること
- [ ] `&` を含む URL（クエリパラメータ）が `&amp;` に正しくエスケープされること
- [ ] `"` を含む URL が属性から脱出しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by properly escaping special characters in link URLs to prevent potential rendering issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->