### PR TITLE
リファクタ: コンテンツ取得定数を fetch-article-content.ts に一元化

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # リリースノート
 
+## 2026-03-26 (36)
+
+### リファクタリング
+- **コンテンツ取得定数を一元化** — `CONTENT_CACHE_TTL_SEC` / `FETCH_TIMEOUT_MS` / `MAX_CONTENT_BYTES` が `fetch-article-content.ts` と `content/route.ts` の両方で同一値として重複していた問題を修正。`fetch-article-content.ts` のみで定義しエクスポート、`route.ts` でインポートするよう変更し、値の乖離によるキャッシュ不整合リスクを排除
+
 ## 2026-03-26 (35)
 
 ### リファクタリング

--- a/app/api/content/route.ts
+++ b/app/api/content/route.ts
@@ -11,10 +11,7 @@ import {
   markdownToHtml,
   postProcessMarkdownContent,
 } from '@/lib/content';
-
-const CONTENT_CACHE_TTL_SEC = 7 * 24 * 60 * 60; // 7日
-const FETCH_TIMEOUT_MS = 10_000;
-const MAX_CONTENT_BYTES = 5 * 1024 * 1024;
+import { CONTENT_CACHE_TTL_SEC, FETCH_TIMEOUT_MS, MAX_CONTENT_BYTES } from '@/lib/fetch-article-content';
 
 export async function GET(request: Request) {
   return withSession(({ ctx }) => handleGet(request, ctx));

--- a/src/lib/fetch-article-content.ts
+++ b/src/lib/fetch-article-content.ts
@@ -15,9 +15,9 @@ import {
 } from '@/lib/content';
 import { isValidFeedUrl } from '@/lib/url';
 
-const CONTENT_CACHE_TTL_SEC = 7 * 24 * 60 * 60;
-const FETCH_TIMEOUT_MS = 10_000;
-const MAX_CONTENT_BYTES = 5 * 1024 * 1024;
+export const CONTENT_CACHE_TTL_SEC = 7 * 24 * 60 * 60;
+export const FETCH_TIMEOUT_MS = 10_000;
+export const MAX_CONTENT_BYTES = 5 * 1024 * 1024;
 
 /**
  * URL から記事コンテンツを取得する。

--- a/src/lib/release-notes-data.ts
+++ b/src/lib/release-notes-data.ts
@@ -4,6 +4,11 @@
  */
 export const RELEASE_NOTES_MARKDOWN = `# リリースノート
 
+## 2026-03-26 (36)
+
+### リファクタリング
+- **コンテンツ取得定数を一元化** — \`CONTENT_CACHE_TTL_SEC\` / \`FETCH_TIMEOUT_MS\` / \`MAX_CONTENT_BYTES\` が \`fetch-article-content.ts\` と \`content/route.ts\` の両方で同一値として重複していた問題を修正。\`fetch-article-content.ts\` のみで定義しエクスポート、\`route.ts\` でインポートするよう変更し、値の乖離によるキャッシュ不整合リスクを排除
+
 ## 2026-03-26 (35)
 
 ### リファクタリング


### PR DESCRIPTION
## Summary

- `CONTENT_CACHE_TTL_SEC` / `FETCH_TIMEOUT_MS` / `MAX_CONTENT_BYTES` が `src/lib/fetch-article-content.ts` と `app/api/content/route.ts` の両方で同一値として重複定義されていた
- `fetch-article-content.ts` のみで `export const` として定義し、`route.ts` でインポートするよう変更
- 両ファイルは同じ Cloudflare Cache キー (`__cache/content/{sha256}`) を使用するため、TTL 等の値が乖離するとキャッシュ不整合が発生するリスクがあった

## Test plan

- [ ] `npm run typecheck` が通ることを確認（実施済み）
- [ ] コンテンツ取得 (`/api/content?url=...`) が正常に動作すること
- [ ] Cloudflare Cache の HIT/MISS が期待通りに動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicated configuration constants for content handling across modules for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->