### PR TITLE
バグ修正: OGP フェッチ失敗・画像なし URL の無駄なリトライを防止

### DIFF
--- a/src/hooks/useOgpCache.ts
+++ b/src/hooks/useOgpCache.ts
@@ -22,6 +22,8 @@ export function useOgpCache(visible: Article[]): Record<string, string> {
   });
 
   const fetchingRef = useRef<Set<string>>(new Set());
+  // 画像なし・エラーだったURLをセッション内でキャッシュし無駄なリトライを防止する
+  const noImageRef = useRef<Set<string>>(new Set());
   // setOgpCache 呼び出し後の再トリガーを避けるため ref で最新値を参照する
   const ogpCacheRef = useRef(ogpCache);
   ogpCacheRef.current = ogpCache;
@@ -33,7 +35,8 @@ export function useOgpCache(visible: Article[]): Record<string, string> {
           !a.ogImage &&
           a.link &&
           !ogpCacheRef.current[a.link] &&
-          !fetchingRef.current.has(a.link),
+          !fetchingRef.current.has(a.link) &&
+          !noImageRef.current.has(a.link),
       )
       .slice(0, FETCH_BATCH_SIZE);
 
@@ -42,7 +45,10 @@ export function useOgpCache(visible: Article[]): Record<string, string> {
     toFetch.forEach((a) => {
       fetchingRef.current.add(a.link);
       fetch(`/api/ogp?url=${encodeURIComponent(a.link)}`)
-        .then((r) => r.json() as Promise<{ image: string }>)
+        .then((r) => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          return r.json() as Promise<{ image: string }>;
+        })
         .then(({ image }) => {
           if (image) {
             setOgpCache((prev) => {
@@ -57,10 +63,14 @@ export function useOgpCache(visible: Article[]): Record<string, string> {
               storageSet(STORAGE_KEYS.OGP_CACHE, JSON.stringify(next));
               return next;
             });
+          } else {
+            // OGP 画像なし: セッション内で再フェッチしないようマーク
+            noImageRef.current.add(a.link);
           }
         })
-        .catch((err) => {
-          console.error('OGP fetch failed:', err);
+        .catch(() => {
+          // フェッチエラー: セッション内で再フェッチしないようマーク
+          noImageRef.current.add(a.link);
         })
         .finally(() => {
           fetchingRef.current.delete(a.link);


### PR DESCRIPTION
## Summary

- `useOgpCache` で OGP 画像フェッチが失敗した場合・画像が存在しない場合でも URL をキャッシュせず、同じ URL に対して繰り返しリクエストを送り続けるバグを修正
- セッション内リトライ防止用の `noImageRef`（`Set<string>`）を追加
- `r.ok` チェックを追加し HTTP エラーレスポンスを適切に例外として処理

## Test plan

- [ ] OGP 画像がない記事を含むフィードを表示し、同一セッション内で同じ URL への `/api/ogp` リクエストが重複して発生しないことを確認
- [ ] OGP 画像が存在する記事では引き続き正常に画像が表示されることを確認
- [ ] ページリロード後は再フェッチが行われる（`noImageRef` はセッション内のみ）ことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance by preventing unnecessary retries of failed image fetch requests within a session. Links that fail to load images are now tracked and skipped on subsequent attempts, resulting in faster browsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->