### PR TITLE
simplify: shared-feed の R2 ページネーション重複ロジックを listPrefixedIds に抽出

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # リリースノート
 
+## 2026-03-26 (45)
+
+### リファクタリング
+- **`shared-feed` R2 ページネーションの重複解消** — `listAllFeedHashes` と `buildFeedUserMap` で重複していた R2 カーソルページネーションロジックを `listPrefixedIds` ヘルパーに抽出
+
 ## 2026-03-26 (44)
 
 ### 新機能

--- a/src/lib/release-notes-data.ts
+++ b/src/lib/release-notes-data.ts
@@ -4,6 +4,11 @@
  */
 export const RELEASE_NOTES_MARKDOWN = `# リリースノート
 
+## 2026-03-26 (45)
+
+### リファクタリング
+- **\`shared-feed\` R2 ページネーションの重複解消** — \`listAllFeedHashes\` と \`buildFeedUserMap\` で重複していた R2 カーソルページネーションロジックを \`listPrefixedIds\` ヘルパーに抽出
+
 ## 2026-03-26 (44)
 
 ### 新機能

--- a/src/lib/shared-feed.ts
+++ b/src/lib/shared-feed.ts
@@ -295,30 +295,27 @@ export async function getUserLatestArticles(
   return sorted.slice(0, 2000);
 }
 
-/** 全 feedHash を R2 の feeds/ プレフィックスから列挙する */
-export async function listAllFeedHashes(bucket: R2Bucket): Promise<string[]> {
-  const hashes: string[] = [];
+/** R2 の prefix/ 直下にある ID（ディレクトリ名）を全件列挙する */
+async function listPrefixedIds(bucket: R2Bucket, prefix: string): Promise<string[]> {
+  const ids: string[] = [];
   let cursor: string | undefined;
   do {
-    const listed = await bucket.list({ prefix: 'feeds/', delimiter: '/', cursor });
-    hashes.push(
-      ...listed.delimitedPrefixes.map((p: string) => p.slice('feeds/'.length, -1)),
-    );
+    const listed = await bucket.list({ prefix, delimiter: '/', cursor });
+    ids.push(...listed.delimitedPrefixes.map((p: string) => p.slice(prefix.length, -1)));
     cursor = listed.truncated ? listed.cursor : undefined;
   } while (cursor);
-  return hashes;
+  return ids;
+}
+
+/** 全 feedHash を R2 の feeds/ プレフィックスから列挙する */
+export async function listAllFeedHashes(bucket: R2Bucket): Promise<string[]> {
+  return listPrefixedIds(bucket, 'feeds/');
 }
 
 /** 全ユーザーの subscriptions.json から feedHash → userId[] の逆引きマップを構築する */
 export async function buildFeedUserMap(bucket: R2Bucket): Promise<Map<string, string[]>> {
   const map = new Map<string, string[]>();
-  const userIds: string[] = [];
-  let cursor: string | undefined;
-  do {
-    const listed = await bucket.list({ prefix: 'users/', delimiter: '/', cursor });
-    userIds.push(...listed.delimitedPrefixes.map((p: string) => p.slice('users/'.length, -1)));
-    cursor = listed.truncated ? listed.cursor : undefined;
-  } while (cursor);
+  const userIds = await listPrefixedIds(bucket, 'users/');
 
   const allSubs = await Promise.all(
     userIds.map(async (uid) => ({ uid, subs: await readUserSubscriptions(bucket, uid) })),


### PR DESCRIPTION
## Summary
- `listAllFeedHashes` と `buildFeedUserMap` で重複していた R2 カーソルページネーションロジックを `listPrefixedIds` プライベートヘルパーに抽出
- 両関数のコードが簡潔になり、将来 R2 ページネーションを変更する場合の修正箇所が 1 か所に集約される

## Test plan
- [ ] `npm run typecheck` 通過確認済み
- [ ] `listAllFeedHashes` / `buildFeedUserMap` の動作は変更なし（リファクタリングのみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal pagination logic for improved code maintainability and reduced duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->