### PR TITLE
simplify: 文字列バリデーションの二重チェックを一本化し定数をモジュールスコープへ移動

### DIFF
--- a/app/api/feeds/[id]/route.ts
+++ b/app/api/feeds/[id]/route.ts
@@ -30,10 +30,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     const parsed = await parseJsonBody<{ title?: unknown }>(request);
     if (!parsed.ok) return parsed.error;
     const body = parsed.data;
-    if (typeof body?.title !== "string") {
-      return NextResponse.json({ error: "title is required" }, { status: 400 });
-    }
-    const title = body.title.trim();
+    const title = typeof body?.title === "string" ? body.title.trim() : "";
     if (!title) return NextResponse.json({ error: "title is required" }, { status: 400 });
     if (title.length > 200) return NextResponse.json({ error: "title too long" }, { status: 400 });
 

--- a/app/api/feeds/route.ts
+++ b/app/api/feeds/route.ts
@@ -30,9 +30,7 @@ export async function POST(request: Request) {
     const parsed = await parseJsonBody<{ url?: unknown }>(request);
     if (!parsed.ok) return parsed.error;
     const body = parsed.data;
-    if (typeof body?.url !== "string")
-      return NextResponse.json({ error: "url is required" }, { status: 400 });
-    let url = body.url.trim();
+    let url = typeof body?.url === "string" ? body.url.trim() : "";
     if (!url) return NextResponse.json({ error: "url is required" }, { status: 400 });
     if (!isValidFeedUrl(url))
       return NextResponse.json({ error: "Invalid URL: must be http or https" }, { status: 400 });

--- a/app/api/read-state/route.ts
+++ b/app/api/read-state/route.ts
@@ -8,6 +8,11 @@ interface ReadState {
   readingListIds: string[];
 }
 
+const MAX_READ_IDS = 20_000;
+const MAX_BOOKMARK_IDS = 2_000;
+const MAX_READING_LIST_IDS = 2_000;
+const MAX_ID_LENGTH = 128;
+
 function r2Key(userId: string) {
   return `users/${userId}/read-state.json`;
 }
@@ -25,11 +30,6 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   return withSession(async ({ session, env }) => {
-    const MAX_READ_IDS = 20_000;
-    const MAX_BOOKMARK_IDS = 2_000;
-    const MAX_READING_LIST_IDS = 2_000;
-    const MAX_ID_LENGTH = 128;
-
     const parsed = await parseJsonBody<Partial<ReadState>>(req);
     if (!parsed.ok) return parsed.error;
     const body = parsed.data;


### PR DESCRIPTION
## Summary

- `app/api/feeds/route.ts`: `url` の型チェックと空チェックを三項演算子で1行に統合（2行→1行）
- `app/api/feeds/[id]/route.ts`: `title` の型チェックと空チェックを三項演算子で1行に統合（3行→1行）
- `app/api/read-state/route.ts`: POSTハンドラ内で毎回定義されていた定数4つをモジュールスコープへ移動

## Test plan

- [ ] `npm run check` パス（Oxlint + Oxfmt）
- [ ] `npm run typecheck` パス（tsc）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal request validation logic for feeds and read-state endpoints to enhance code consistency and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->