### PR TITLE
feat: XML カスタムフィールドのメタデータフィルタリング対応

### DIFF
--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -292,6 +292,30 @@ interface FilterMenuProps {
   showToast?: (msg: string) => void;
 }
 
+/** XML キーを日本語ラベルに変換する */
+function metaLabel(key: string): string {
+  const map: Record<string, string> = {
+    "dc:corp": "企業",
+    "dc:creator": "著者",
+    "dc:subject": "テーマ",
+    "dc:publisher": "出版社",
+    "dc:type": "種別",
+    "dc:rights": "権利",
+    business_form: "業種",
+    service: "サービス",
+    industry: "業界",
+    category: "カテゴリ",
+    tag: "タグ",
+    source: "情報源",
+    department: "部署",
+    genre: "ジャンル",
+    region: "地域",
+    prefecture: "都道府県",
+    country: "国",
+  };
+  return map[key] ?? key.replace(/^[a-z]+:/i, "");
+}
+
 function FilterMenu({ article, feed, onSaveFilter, showToast }: FilterMenuProps) {
   const [open, setOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
@@ -309,28 +333,55 @@ function FilterMenu({ article, feed, onSaveFilter, showToast }: FilterMenuProps)
   const hasFilter =
     feed.filter && (feed.filter.include.length > 0 || feed.filter.exclude.length > 0);
 
-  async function handleQuickExclude() {
+  async function handleExclude(value: string) {
     setOpen(false);
     const existingExclude = feed.filter?.exclude ?? [];
-    if (existingExclude.includes(article.title)) {
+    if (existingExclude.includes(value)) {
       showToast?.("既に除外キーワードに登録されています");
       return;
     }
     const newFilter: KeywordFilter = {
       include: feed.filter?.include ?? [],
-      exclude: [...existingExclude, article.title],
+      exclude: [...existingExclude, value],
       matchCategories: feed.filter?.matchCategories,
     };
     try {
       await onSaveFilter(feed.id, newFilter);
-      showToast?.("記事タイトルを除外キーワードに追加しました");
+      showToast?.(`「${value}」を除外キーワードに追加しました`);
     } catch {
       showToast?.("フィルターの保存に失敗しました");
     }
   }
 
+  // 除外候補を動的に生成する
+  const excludeOptions: { label: string; value: string }[] = [
+    { label: "この記事", value: article.title },
+    ...(article.author ? [{ label: `著者「${article.author}」`, value: article.author }] : []),
+    ...(article.categories ?? []).map((cat) => ({ label: `カテゴリ「${cat}」`, value: cat })),
+    ...(article.metadata ?? []).map((m) => ({
+      label: `${metaLabel(m.key)}「${m.value}」`,
+      value: m.value,
+    })),
+  ];
+
   const itemCls =
     "w-full flex items-center gap-2 px-3 py-2 text-[12px] text-text-default hover:bg-surface-subtle transition-colors text-left";
+
+  const XIcon = (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="flex-shrink-0"
+    >
+      <path d="M18 6L6 18M6 6l12 12" />
+    </svg>
+  );
 
   return (
     <div ref={menuRef} className="relative">
@@ -353,7 +404,7 @@ function FilterMenu({ article, feed, onSaveFilter, showToast }: FilterMenuProps)
         </svg>
       </button>
       {open && (
-        <div className="absolute right-0 top-full mt-1 z-30 bg-surface-elevated border border-border-default rounded-lg shadow-lg overflow-hidden min-w-[180px]">
+        <div className="absolute right-0 top-full mt-1 z-30 bg-surface-elevated border border-border-default rounded-lg shadow-lg overflow-hidden min-w-[200px] max-h-[320px] overflow-y-auto">
           <button
             onClick={() => {
               setOpen(false);
@@ -362,34 +413,37 @@ function FilterMenu({ article, feed, onSaveFilter, showToast }: FilterMenuProps)
             className={itemCls}
           >
             <svg
-              width="12"
-              height="12"
+              width="10"
+              height="10"
               viewBox="0 0 24 24"
               fill="none"
               stroke="currentColor"
               strokeWidth={1.5}
               strokeLinecap="round"
               strokeLinejoin="round"
+              className="flex-shrink-0"
             >
               <path d="M3 4h18M7 8h10M11 12h2M9 16h6" />
             </svg>
             キーワードフィルター設定
           </button>
-          <button onClick={() => void handleQuickExclude()} className={itemCls}>
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={1.5}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M18 6L6 18M6 6l12 12" />
-            </svg>
-            この記事を除外
-          </button>
+          {excludeOptions.length > 0 && (
+            <div className="border-t border-border-subtle">
+              <p className="px-3 pt-2 pb-1 text-[10px] font-medium tracking-[0.15em] uppercase text-text-muted">
+                除外する
+              </p>
+              {excludeOptions.map((opt) => (
+                <button
+                  key={opt.value}
+                  onClick={() => void handleExclude(opt.value)}
+                  className={itemCls}
+                >
+                  {XIcon}
+                  <span className="truncate">{opt.label}</span>
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       )}
       {modalOpen && (

--- a/src/cron/fetch.ts
+++ b/src/cron/fetch.ts
@@ -123,6 +123,7 @@ async function buildArticle(
     publishedAt: item.publishedAt,
     createdAt: existing?.createdAt ?? new Date().toISOString(),
     categories: item.categories.length > 0 ? item.categories : existing?.categories,
+    metadata: item.metadata.length > 0 ? item.metadata : existing?.metadata,
   };
 }
 

--- a/src/lib/keyword-filter.ts
+++ b/src/lib/keyword-filter.ts
@@ -7,6 +7,9 @@ export function matchesKeywordFilter(article: Article, filter: KeywordFilter): b
   if (matchCategories && article.categories) {
     fields.push(...article.categories);
   }
+  if (article.metadata) {
+    fields.push(...article.metadata.map((m) => m.value));
+  }
   const text = fields.join(" ").toLowerCase();
 
   if (exclude.length > 0 && exclude.some((kw) => text.includes(kw.toLowerCase()))) {

--- a/src/lib/llm-feed-generator.ts
+++ b/src/lib/llm-feed-generator.ts
@@ -287,6 +287,7 @@ export function scrapeFeed(
       author: "",
       publishedAt: null,
       categories: [],
+      metadata: [],
     });
   }
 

--- a/src/lib/xml-parser.ts
+++ b/src/lib/xml-parser.ts
@@ -75,6 +75,8 @@ export interface ParsedItem {
   author: string;
   publishedAt: string | null;
   categories: string[];
+  /** 標準フィールド以外のカスタム XML タグ値（dc:corp, business_form 等） */
+  metadata: Array<{ key: string; value: string }>;
 }
 
 export interface ParsedFeed {
@@ -136,6 +138,59 @@ function str(val: unknown): string {
     return String((val as { "#text": unknown })["#text"]);
   return String(val);
 }
+
+/**
+ * RSS アイテムからカスタムフィールド値を抽出する。
+ * skipKeys に含まれる標準フィールドと属性キー（@_ 接頭辞）は除外する。
+ * HTML を含む長い値は 500 文字に切り詰める。
+ */
+function extractMetadata(
+  item: Record<string, unknown>,
+  skipKeys: Set<string>,
+): Array<{ key: string; value: string }> {
+  const entries: Array<{ key: string; value: string }> = [];
+  for (const [key, val] of Object.entries(item)) {
+    if (skipKeys.has(key) || key.startsWith("@_") || key === "#text") continue;
+    const value = str(val).trim().slice(0, 500);
+    if (value) entries.push({ key, value });
+  }
+  return entries;
+}
+
+const RSS2_SKIP_KEYS = new Set([
+  "title",
+  "link",
+  "description",
+  "content:encoded",
+  "dc:creator",
+  "dc:date",
+  "author",
+  "pubDate",
+  "guid",
+  "category",
+  "enclosure",
+  "media:thumbnail",
+  "media:content",
+  "media:group",
+]);
+
+const ATOM_SKIP_KEYS = new Set([
+  "title",
+  "link",
+  "id",
+  "content",
+  "summary",
+  "author",
+  "published",
+  "updated",
+  "category",
+  "enclosure",
+  "media:thumbnail",
+  "media:content",
+  "media:group",
+]);
+
+const RDF_SKIP_KEYS = new Set([...RSS2_SKIP_KEYS, "@_rdf:about"]);
 
 /** author フィールドから表示名を取得する（Atom の author.name / RSS の dc:creator 両対応） */
 function authorStr(author: FeedItem["author"]): string {
@@ -269,6 +324,7 @@ function parseJsonFeed(data: JsonFeedRoot): ParsedFeed {
       author,
       publishedAt: parseDate(item.date_published ?? item.date_modified ?? null),
       categories: item.tags ?? [],
+      metadata: [],
     };
   });
   return { title: data.title ?? "", siteUrl: data.home_page_url ?? "", items };
@@ -311,6 +367,7 @@ export function parseFeed(xml: string): ParsedFeed {
           categories: toArray(item.category)
             .map((c) => str(c))
             .filter(Boolean),
+          metadata: extractMetadata(item as unknown as Record<string, unknown>, RSS2_SKIP_KEYS),
         };
       }),
     };
@@ -347,6 +404,7 @@ export function parseFeed(xml: string): ParsedFeed {
                 : str(c),
             )
             .filter(Boolean),
+          metadata: extractMetadata(entry as unknown as Record<string, unknown>, ATOM_SKIP_KEYS),
         };
       }),
     };
@@ -376,6 +434,7 @@ export function parseFeed(xml: string): ParsedFeed {
           categories: toArray(item.category)
             .map((c) => str(c))
             .filter(Boolean),
+          metadata: extractMetadata(item as unknown as Record<string, unknown>, RDF_SKIP_KEYS),
         };
       }),
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,8 @@ export interface Article {
   publishedAt: string | null;
   createdAt: string;
   categories?: string[];
+  /** RSS フィード固有の追加フィールド値（dc:corp, business_form 等） */
+  metadata?: Array<{ key: string; value: string }>;
 }
 
 export type Layout = "compact" | "list" | "card" | "magazine";


### PR DESCRIPTION
## Summary

- **`metadata` フィールド追加**: `Article` / `ParsedItem` に `metadata: {key, value}[]` を追加。`dc:corp`、`business_form` 等の非標準 XML タグ値を保持
- **パーサー拡張**: RSS 2.0 / Atom / RSS 1.0 で `extractMetadata()` により標準フィールド以外の値を自動抽出・保存
- **フィルタリング対応**: `keyword-filter` でメタデータ値もキーワード検索対象に追加
- **除外メニュー拡張**: `ArticleView` の FilterMenu に動的除外オプションを追加
  - この記事（タイトル）
  - 著者
  - カテゴリ（複数対応）
  - メタデータ値（企業・業種・テーマ等、XML キーを日本語ラベルに変換）

## Test plan

- [ ] PRTimes 等 `dc:corp` を含むフィードで記事詳細を開き、フィルターメニューに「企業「○○」を除外」が表示されることを確認
- [ ] 著者・カテゴリが存在する記事でそれぞれの除外ボタンが表示されることを確認
- [ ] ワンクリックで除外キーワードが追加され、対象記事が非表示になることを確認
- [ ] 既に除外済みのキーワードを再追加しようとした際にトーストが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded exclusion filter options to include author, category, and additional feed-provided metadata fields beyond article titles.
  * Enhanced keyword filtering now includes feed metadata values for improved search matching and relevance.
  * Articles now capture and display additional metadata from RSS feeds for comprehensive filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->