### PR TITLE
fix: セッション refresh 失敗時の不正な Cookie 削除を修正

### DIFF
--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -49,38 +49,41 @@ export async function GET(request: Request) {
   if (refreshToken) {
     const refreshed = await refreshTokens(refreshToken);
     if (refreshed) {
+      // リフレッシュ成功 → verify 結果に関わらず新しいトークンを Cookie にセット
+      // （verify 失敗は JWKS 一時障害の可能性があるため Cookie は残す）
       const r = await verifyAndLoad(refreshed.access_token, authBaseUrl, env);
       if (r.kind === "restricted") return NextResponse.json({ user: null, betaRestricted: true });
-      if (r.kind === "ok") {
-        const res = NextResponse.json({ user: r.profile });
-        res.cookies.set("access_token", refreshed.access_token, { ...COOKIE_OPTS, maxAge: 900 });
-        res.cookies.set("refresh_token", refreshed.refresh_token, {
-          ...COOKIE_OPTS,
-          maxAge: 30 * 24 * 60 * 60,
-        });
-        // クライアントサイドからトークン有効期限を読めるよう non-HttpOnly で token_exp をセット
-        try {
-          const parts = refreshed.access_token.split(".");
-          if (parts.length >= 2) {
-            const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/"))) as {
-              exp?: number;
-            };
-            if (typeof payload.exp === "number") {
-              res.cookies.set("token_exp", String(payload.exp), {
-                maxAge: 900,
-                httpOnly: false,
-                secure: true,
-                sameSite: "lax",
-                path: "/",
-              });
-            }
+
+      const body = r.kind === "ok" ? { user: r.profile } : { user: null };
+      const res = NextResponse.json(body);
+      res.cookies.set("access_token", refreshed.access_token, { ...COOKIE_OPTS, maxAge: 900 });
+      res.cookies.set("refresh_token", refreshed.refresh_token, {
+        ...COOKIE_OPTS,
+        maxAge: 30 * 24 * 60 * 60,
+      });
+      // クライアントサイドからトークン有効期限を読めるよう non-HttpOnly で token_exp をセット
+      try {
+        const parts = refreshed.access_token.split(".");
+        if (parts.length >= 2) {
+          const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/"))) as {
+            exp?: number;
+          };
+          if (typeof payload.exp === "number") {
+            res.cookies.set("token_exp", String(payload.exp), {
+              maxAge: 900,
+              httpOnly: false,
+              secure: true,
+              sameSite: "lax",
+              path: "/",
+            });
           }
-        } catch {
-          // exp 取得失敗は無視
         }
-        return res;
+      } catch {
+        // exp 取得失敗は無視
       }
+      return res;
     }
+    // リフレッシュ失敗（refresh_token 無効）→ Cookie を削除してログアウト
     const res = NextResponse.json({ user: null });
     res.cookies.delete("access_token");
     res.cookies.delete("refresh_token");

--- a/src/lib/server-auth.ts
+++ b/src/lib/server-auth.ts
@@ -53,8 +53,6 @@ export function isBetaAllowed(sub: string): boolean {
 export interface AuthSession {
   userId: string;
   refreshedTokens?: { access_token: string; refresh_token: string };
-  /** リフレッシュ試行が失敗した場合 true。Cookie クリアが必要 */
-  refreshFailed?: boolean;
 }
 
 /**
@@ -85,27 +83,23 @@ export async function getAuthSession(): Promise<AuthSession | null> {
         return { userId: payload.sub, refreshedTokens: refreshed };
       }
     }
-    // リフレッシュ失敗 → 壊れた Cookie をクリアするためセッションに失敗フラグを付与
-    return { userId: "", refreshFailed: true };
+    // リフレッシュ失敗 → null を返す（Cookie 削除は me/route のみが担う）
+    return null;
   }
 
   return null;
 }
 
-/** セッション取得 + 認証失敗時は 401 を返すヘルパー */
+/** セッション取得 + 認証失敗時は 401 を返すヘルパー。
+ * Cookie の削除は行わない（me/route のみが担う）。
+ * これにより、並行リクエストの refresh 競合で Cookie が消える問題を防ぐ。
+ */
 export async function requireSession(): Promise<
   { session: AuthSession } | { error: NextResponse }
 > {
   const session = await getAuthSession();
-  if (!session || session.refreshFailed) {
-    const res = NextResponse.json({ error: { code: "UNAUTHORIZED" } }, { status: 401 });
-    if (session?.refreshFailed) {
-      // リフレッシュ失敗時は壊れた Cookie を削除する
-      res.cookies.delete("access_token");
-      res.cookies.delete("refresh_token");
-      res.cookies.delete("token_exp");
-    }
-    return { error: res };
+  if (!session) {
+    return { error: NextResponse.json({ error: { code: "UNAUTHORIZED" } }, { status: 401 }) };
   }
   return { session };
 }


### PR DESCRIPTION
## 問題

access_token 期限切れ時に refresh が成功しているにもかかわらずログアウトされる。

**根本原因: 並行リクエストによる refresh token rotation 競合**

1. access_token 期限切れ → 複数の API リクエストが同時に `withSession` を通る
2. 各リクエストが独立して `refreshTokens()` を呼ぶ
3. auth サーバーは refresh token rotation を採用 → 最初の1件のみ成功、残りは失敗
4. 失敗した `requireSession()` が `cookies.delete()` を実行
5. 成功した別リクエストがセットした新しい Cookie を上書き削除
6. ログアウト

## 修正内容

- **`requireSession()` から Cookie 削除を除去**: 401 を返すだけにし、Cookie は一切触らない。Cookie の管理権限を `me/route` のみに集約
- **`me/route`: refresh 成功時は verify 失敗でも Cookie を保持**: JWKS 一時障害等で `verifyAndLoad` が失敗しても新トークンの Cookie をセットしてから `user: null` を返す。`refreshTokens` 自体が null を返した場合（= refresh token 無効）のみ Cookie を削除
- **`AuthSession.refreshFailed` フラグを削除**: 不要になったため除去

## 修正後のフロー

1. API 呼び出しが 401 → Cookie は削除されない
2. `apiFetch` の 401 リトライ → `/api/auth/me` を呼ぶ
3. `me/route` が refresh_token で refresh → 成功 → 新 Cookie をセット
4. リトライ成功

## Test plan

- [ ] access_token 期限切れ時（15分後）に自動リフレッシュされセッションが継続されることを確認
- [ ] タブをバックグラウンドに置いた後に復帰してもログアウトされないことを確認
- [ ] 意図的なログアウト（POST /api/auth/logout）は引き続き正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in authentication token refresh handling and cookie management.
  * Simplified session error handling for more reliable authentication flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->