### PR TITLE
ドキュメント: useFilteredArticles の複雑な状態管理にコメントを追加 (#45)

### DIFF
--- a/src/hooks/useFilteredArticles.ts
+++ b/src/hooks/useFilteredArticles.ts
@@ -176,7 +176,9 @@ export function useFilteredArticles({
   const dateRangeRef = useSyncedRef(dateRange);
   const readingTimeRangeRef = useSyncedRef(readingTimeRange);
 
-  // 直前に選択していた記事を一定時間フィルター対象外にする（未読フィルター中でも前の記事に戻れるように）
+  // selectedArticleId が変化した直後、前の記事 ID を 30 秒間保持する（useGracePeriod 参照）。
+  // 未読フィルターがオンの状態で記事を読み終えると selectedArticleId が null になり、
+  // 既読になった記事はフィルターで除外されて前の記事に戻れなくなる問題を回避するために使用。
   const gracePeriodId = useGracePeriod(selectedArticleId);
 
   // フィード切り替え時にページ・検索クエリ・著者フィルター・カテゴリフィルターをリセット
@@ -250,8 +252,9 @@ export function useFilteredArticles({
   const notifyArticlesAdded = useCallback(() => {
     setServerLoadCount((c) => c + 1);
   }, []);
-  // 現在表示中の記事は既読でもリストに残す（前後ナビが消えないようにするため）
-  // gracePeriodId: 直前まで表示していた記事を5秒間保持（未読フィルター中でも前の記事に戻れるように）
+  // activeIds に含まれる記事はフィルター条件（未読のみ等）に関わらず常にリストに残す。
+  // - selectedArticleId: 現在開いている記事（前後ナビのキーが消えないようにするため）
+  // - gracePeriodId: 直前まで開いていた記事（30 秒間保持。前の記事に j/k で戻れるようにするため）
   const activeIds = useMemo(() => {
     const ids = new Set<string>();
     if (selectedArticleId) ids.add(selectedArticleId);
@@ -276,7 +279,9 @@ export function useFilteredArticles({
       new Map(feeds.filter((f) => f.category).map((f) => [f.id, f.category!] as [string, string])),
     [feeds],
   );
-  // globalFilter も feedFilterMap と同様に変更時だけ正規化（filterAndSortArticles の hot path から除外）
+  // globalFilter の正規化（キーワード文字列 → CompiledKeywordFilter への変換）を useMemo でキャッシュ。
+  // filterAndSortArticles は全記事をループする hot path のため、正規表現コンパイルをループ外に出すことで
+  // 記事ごとの不要な RegExp 生成を回避する。feedFilterMap と同じ戦略（変更時のみ再ビルド）。
   const normalizedGlobalFilter = useMemo(
     () => (globalFilter ? normalizeFilter(globalFilter) : null),
     [globalFilter],
@@ -349,6 +354,10 @@ export function useFilteredArticles({
     ],
   );
 
+  // filteredRef: サーバーロード後の page 拡張で filtered.length を読み取るために使用。
+  // filtered を deps に含めると、通常のフィルター切り替え（未読のみ ON/OFF など）でも
+  // このエフェクトが発火してしまう。serverLoadCount の変化時だけ発火させることで、
+  // LoadMoreButton 経由でサーバーからデータが追加された後にのみ page を拡張できる。
   const filteredRef = useSyncedRef(filtered);
   useEffect(() => {
     if (serverLoadCount === 0) return;


### PR DESCRIPTION
## 概要

issue #45 対応。`useFilteredArticles.ts` の複雑なロジックにコメントを追加。

## 変更内容

- **gracePeriodId**: 30秒間保持の目的と「未読フィルター中に前の記事に戻れなくなる問題」の回避理由を説明
- **activeIds**: `selectedArticleId` / `gracePeriodId` それぞれの役割をコメントで明示
  - 誤記「5秒間」→「30秒間」を修正（`GRACE_PERIOD_MS = 30000` に合わせる）
- **normalizedGlobalFilter**: hot path での RegExp 再生成を避けるメモ化戦略を説明
- **filteredRef**: `filtered` を deps に含めない理由（通常のフィルター切り替えで誤発火しないため）を説明

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized article filtering and search performance by implementing memoization for keyword normalization, reducing unnecessary recompilation when users apply or toggle filter conditions.
  * Enhanced article navigation stability during filter changes by improving state management for article selection, ensuring consistent navigation behavior between articles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->