### PR TITLE
セキュリティ: sanitizeKeywords にサーバー側 ReDoS 検証を追加 (close #43)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ## 2026-04-16
 
+### セキュリティ
+
+- **`sanitizeKeywords` でサーバー側 ReDoS 検証を追加** — `/api/read-state` POST で受け取ったキーワードフィルターにおいて、クライアント側でのみ行っていた `hasCatastrophicBacktracking` チェックを `sanitizeKeywords` にも追加。API を直接叩いた悪意あるユーザーが ReDoS パターンを R2 に保存できる問題を修正。
+
 ### バグ修正
 
 - **`useReadState` の `syncImmediately` に存在した race condition を修正** — 削除操作後のページリロード時、`syncImmediately` が予約した `setTimeout(0)` のIDを `syncTimerRef` に保持していなかったため、`beforeunload` / `visibilitychange hidden` の `flushIfPending` がタイマーを検出できず `sendBeacon` が発火しないケースがあった。`syncTimerRef.current` にIDを保存し、`isDirtyRef` を `true` に保つよう修正。

--- a/src/lib/keyword-filter.ts
+++ b/src/lib/keyword-filter.ts
@@ -94,7 +94,13 @@ export function sanitizeKeywords(arr: unknown[]): string[] {
       arr
         .filter((x): x is string => typeof x === "string")
         .map((s) => s.trim().slice(0, MAX_KEYWORD_LENGTH))
-        .filter(Boolean),
+        .filter(Boolean)
+        .filter((kw) => {
+          if (!isRegexKeyword(kw)) return true;
+          // サーバー側でも ReDoS パターンを除外する
+          const pattern = kw.slice(1, -1);
+          return !hasCatastrophicBacktracking(pattern);
+        }),
     ),
   ].slice(0, MAX_KEYWORDS_PER_ARRAY);
 }

--- a/src/lib/release-notes-data.ts
+++ b/src/lib/release-notes-data.ts
@@ -6,6 +6,10 @@ export const RELEASE_NOTES_MARKDOWN = `# リリースノート
 
 ## 2026-04-16
 
+### セキュリティ
+
+- **\`sanitizeKeywords\` でサーバー側 ReDoS 検証を追加** — \`/api/read-state\` POST で受け取ったキーワードフィルターにおいて、クライアント側でのみ行っていた \`hasCatastrophicBacktracking\` チェックを \`sanitizeKeywords\` にも追加。API を直接叩いた悪意あるユーザーが ReDoS パターンを R2 に保存できる問題を修正。
+
 ### バグ修正
 
 - **\`useReadState\` の \`syncImmediately\` に存在した race condition を修正** — 削除操作後のページリロード時、\`syncImmediately\` が予約した \`setTimeout(0)\` のIDを \`syncTimerRef\` に保持していなかったため、\`beforeunload\` / \`visibilitychange hidden\` の \`flushIfPending\` がタイマーを検出できず \`sendBeacon\` が発火しないケースがあった。\`syncTimerRef.current\` にIDを保存し、\`isDirtyRef\` を \`true\` に保つよう修正。


### PR DESCRIPTION
## Summary

- `sanitizeKeywords` 関数に `hasCatastrophicBacktracking` チェックを追加
- クライアント側のみで行っていた ReDoS パターン検出をサーバー側にも適用
- `/api/read-state` POST 経由で悪意あるユーザーが ReDoS パターンを R2 に保存できる問題を修正

## Test plan

- [ ] `npm run typecheck` — 型エラーなし
- [ ] `npm run check` — lint/format エラーなし
- [ ] 正規表現キーワード `/(a+)+/` 等の ReDoS パターンが `sanitizeKeywords` で除外されること
- [ ] 正常な正規表現 `/foo/` が引き続き保存できること

close #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added server-side validation for keyword filters to prevent malicious regex patterns from being stored via API calls.

* **Documentation**
  * Updated release notes to document security improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->