### PR TITLE
依存関係更新の自動化: Dependabot grouping + CI + auto-merge ワークフロー

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # npm 依存関係
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -10,9 +11,61 @@ updates:
     cooldown:
       default-days: 3
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "依存関係更新"
+      include: "scope"
+    groups:
+      # 型システム・TypeScript 周辺
+      typescript:
+        patterns:
+          - "typescript"
+          - "@typescript/*"
+          - "@types/*"
+      # Cloudflare Workers エコシステム
+      cloudflare:
+        patterns:
+          - "@cloudflare/*"
+          - "@opennextjs/*"
+          - "wrangler"
+          - "miniflare"
+      # Next.js / React
+      nextjs:
+        patterns:
+          - "next"
+          - "react"
+          - "react-dom"
+      # Tailwind / PostCSS
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "postcss"
+      # テスト
+      testing:
+        patterns:
+          - "@playwright/*"
+          - "playwright"
+          - "vitest"
+          - "@vitest/*"
+      # ビルドツール
+      build:
+        patterns:
+          - "vite"
+          - "vite-plus"
+          - "esbuild"
+      # コンテンツ処理（パーサー・サニタイザー・変換）
+      content-libs:
+        patterns:
+          - "fast-xml-parser"
+          - "marked"
+          - "katex"
+          - "highlight.js"
+          - "linkedom"
+          - "@mozilla/readability"
     labels:
       - "dependencies"
 
+  # GitHub Actions の依存関係
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -22,6 +75,13 @@ updates:
       timezone: "Asia/Tokyo"
     cooldown:
       default-days: 3
+    commit-message:
+      prefix: "依存関係更新"
+      include: "scope"
+    groups:
+      actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  check:
+    name: lint・fmt・型チェック
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: チェックアウト
+        uses: actions/checkout@v6
+
+      - name: pnpm セットアップ
+        uses: pnpm/action-setup@v4
+
+      - name: Node.js セットアップ
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: 依存パッケージインストール
+        run: pnpm install --frozen-lockfile
+
+      - name: check（lint + fmt + typecheck）
+        run: pnpm run check
+
+      - name: 型チェック（tsc）
+        run: pnpm run typecheck

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,48 @@
+name: Dependabot auto-merge
+
+# Dependabot が作成した PR のうち、patch / minor バージョンアップを
+# CI 通過後に自動的に auto-merge する。
+# major バージョンは破壊的変更の可能性があるため人手レビューを必須とする。
+#
+# 前提:
+#   - リポジトリ設定で Allow auto-merge が有効化
+#   - master への branch protection で CI (`.github/workflows/ci.yml`) を
+#     required status check に指定していると、CI 通過まで実際にマージを待機する
+#     （未設定の場合、auto-merge は即時マージ相当の挙動になる点に注意）
+#
+# 注記:
+#   GITHUB_TOKEN では自分が作成した PR を approve できないため approve は実施しない。
+#   branch protection で approval が必須になっている場合は、
+#   別途 PAT を secrets に登録してそのトークンで approve するワークフローを追加すること。
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependabot メタデータ取得
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: patch / minor は auto-merge 有効化
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: major はコメントのみ（手動レビュー必須）
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: gh pr comment "$PR_URL" --body "メジャーバージョンアップのため自動マージは行いません。CHANGELOG を確認のうえ手動で対応してください。"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
 
 ### 新機能
 
+- **依存関係更新の自動化** — Dependabot 設定 (`.github/dependabot.yml`) にエコシステム別のグルーピング（typescript / cloudflare / nextjs / tailwind / testing / build / content-libs）と日本語コミットプレフィックスを追加し、毎週月曜 09:00 JST に集約された PR が起票されるようにした。CI ワークフロー (`.github/workflows/ci.yml`) で master push と PR 時に `pnpm install --frozen-lockfile` → `pnpm run check` → `pnpm run typecheck` を実行。Dependabot auto-merge ワークフロー (`.github/workflows/dependabot-auto-merge.yml`) は patch / minor を CI 通過後に自動 squash マージし、major はコメントのみで人手レビューを必須にする。GitHub Actions 自体も同 Dependabot 設定で更新対象に含める。
+
 - **認証不要のデモページ `/demo` を追加** — 0g0 ID ログイン必須だったためデザイン／動作確認に毎回ログインが必要だった問題を解消。`/demo` にアクセスすると fetch インターセプターが `/api/*` をすべてモックレスポンス（固定のユーザー・フィード・記事・グループ・読み取り状態）に差し替えた状態で本物の `App` コンポーネントを描画する。デモ用に追加した実装ファイルは `app/demo/page.tsx` / `app/demo/DemoApp.tsx` / `app/demo/mock.ts` のみ — アプリ本体には一切の条件分岐を入れていないため、デモモードが本番描画ロジックに影響しない。`window.fetch` の置き換えは HMR / ページ再読み込みに耐えるよう `globalThis.__demoFetchOriginal` に native fetch を一度だけ保存、インターセプター内で `window.location.pathname.startsWith("/demo")` を毎回確認し、クライアントサイドナビゲーションで他パスに出た瞬間からは本物の API レスポンスを通す設計。`.playwright-mcp/` / `demo-*.png` を `.gitignore` に追加。
 
 ### バグ修正

--- a/src/lib/release-notes-data.ts
+++ b/src/lib/release-notes-data.ts
@@ -8,6 +8,8 @@ export const RELEASE_NOTES_MARKDOWN = `# リリースノート
 
 ### 新機能
 
+- **依存関係更新の自動化** — Dependabot 設定 (\`.github/dependabot.yml\`) にエコシステム別のグルーピング（typescript / cloudflare / nextjs / tailwind / testing / build / content-libs）と日本語コミットプレフィックスを追加し、毎週月曜 09:00 JST に集約された PR が起票されるようにした。CI ワークフロー (\`.github/workflows/ci.yml\`) で master push と PR 時に \`pnpm install --frozen-lockfile\` → \`pnpm run check\` → \`pnpm run typecheck\` を実行。Dependabot auto-merge ワークフロー (\`.github/workflows/dependabot-auto-merge.yml\`) は patch / minor を CI 通過後に自動 squash マージし、major はコメントのみで人手レビューを必須にする。GitHub Actions 自体も同 Dependabot 設定で更新対象に含める。
+
 - **認証不要のデモページ \`/demo\` を追加** — 0g0 ID ログイン必須だったためデザイン／動作確認に毎回ログインが必要だった問題を解消。\`/demo\` にアクセスすると fetch インターセプターが \`/api/*\` をすべてモックレスポンス（固定のユーザー・フィード・記事・グループ・読み取り状態）に差し替えた状態で本物の \`App\` コンポーネントを描画する。デモ用に追加した実装ファイルは \`app/demo/page.tsx\` / \`app/demo/DemoApp.tsx\` / \`app/demo/mock.ts\` のみ — アプリ本体には一切の条件分岐を入れていないため、デモモードが本番描画ロジックに影響しない。\`window.fetch\` の置き換えは HMR / ページ再読み込みに耐えるよう \`globalThis.__demoFetchOriginal\` に native fetch を一度だけ保存、インターセプター内で \`window.location.pathname.startsWith("/demo")\` を毎回確認し、クライアントサイドナビゲーションで他パスに出た瞬間からは本物の API レスポンスを通す設計。\`.playwright-mcp/\` / \`demo-*.png\` を \`.gitignore\` に追加。
 
 ### バグ修正


### PR DESCRIPTION
## Summary

- 参考リポジトリ [g-kari/0g0-id](https://github.com/g-kari/0g0-id) と同等の依存関係更新自動化を導入
- `.github/dependabot.yml`: エコシステム別 grouping（typescript / cloudflare / nextjs / tailwind / testing / build / content-libs）と日本語 `commit-message.prefix` を追加。週次集約 PR で確認コストを削減
- `.github/workflows/ci.yml`: master push / PR で `pnpm install --frozen-lockfile` → `pnpm run check` → `pnpm run typecheck` を実行
- `.github/workflows/dependabot-auto-merge.yml`: patch / minor は CI 通過後に auto squash merge、major はコメントのみで人手レビュー必須

## 前提（マージ後に手動設定が必要）

- リポジトリ Settings → General → **Allow auto-merge** を有効化
- master の branch protection で **Require status checks** に `lint・fmt・型チェック`（CI ジョブ）を指定すると、CI 通過まで auto-merge が待機

## Test plan

- [ ] master マージ後、CI ワークフローが master push で起動することを確認
- [ ] 次回 dependabot PR で patch/minor が auto-merge される挙動を確認
- [ ] major バージョンアップ PR ではコメントのみで止まる挙動を確認