### PR TITLE
バグ修正: popup-lock 未登録だったインラインモーダルを追補 (Issue #81)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
 
 ### バグ修正
 
+- **幅調整バーのポップアップ対応漏れを追補** — Issue #81 の初版修正で拾えていなかった未ポートアル系のインラインモーダル（`ArticleView` の画像ダウンロード確認モーダル / `ImageGallery` の全画面ライトボックス / `SelectionExcludePopup`）にも `usePopupLock` を追加。さらに `e2e/modal-popup-lock-coverage.spec.ts` に静的検査テストを追加し、`fixed inset-0 z-5*` のフルスクリーンオーバーレイを持つコンポーネントは `usePopupLock` / `usePortalMenu` のいずれかを呼ぶことを CI で強制することで、今後のモーダル追加時の漏れを防ぐ（Issue #81 再発防止）。
+
 - **幅調整バーがポップアップ表示中も操作できる問題を修正** — 記事一覧 / フィード一覧 / 記事詳細の 3 ペイン境界にある幅調整バーが、モーダル・ドロップダウン表示中も pointer イベントを受けてドラッグできてしまい、オーバーレイより手前に見えてしまう不具合を修正（Issue #81）。`src/lib/popup-lock.ts` にグローバルなポップアップ表示数カウンタを追加し、`src/hooks/usePopupLock.ts`（`usePopupLock(active?)` / `useHasOpenPopup()`）を経由して登録・購読できるようにした。`Modal`（`FeedDetailModal` / `FeedFilterModal` / `KeyboardShortcutsModal` / `ReadingStatsModal` / `ReleaseNotesModal` / `SnoozeModal` が共通利用）、`FeedQuickSwitchModal`、`usePortalMenu`（`FilterMenu` / `GlobalFilterMenu` / `ShareMenu` / `SnoozeMenu` など）、および `FeedItem` のコンテキスト／ミュート／グループ移動メニューが表示中はロックを立てる。`App.tsx` のリサイズハンドルは `useHasOpenPopup()` を監視し、`z-[5]`（従来 `z-20`）へ引き下げたうえで表示中は `pointer-events-none` + `opacity-0` + `aria-hidden` を付与して操作不可にする。`e2e/popup-lock.spec.ts` にカウンタ増減・冪等性・通知購読の 6 ケースを追加。
 
 ### 新機能

--- a/e2e/modal-popup-lock-coverage.spec.ts
+++ b/e2e/modal-popup-lock-coverage.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * `fixed inset-0 z-5*` のフルスクリーンオーバーレイを持つコンポーネントはすべて
+ * `usePopupLock` を呼んでいることを保証する静的検査（Issue #81 再発防止）。
+ *
+ * ロック未取得のモーダルがあると幅調整バーが表示中も操作できてしまう。
+ * 新たにモーダルを追加する場合は `usePopupLock()`（常時）または
+ * `usePopupLock(flag)`（条件付き）を呼ぶこと。
+ *
+ * 例外: `createPortal` でレンダリングしている上で `usePortalMenu` を使っている場合は
+ * `usePortalMenu` 側で `usePopupLock(open)` 済みのため、直接呼ぶ必要はない。
+ */
+
+const SRC_DIR = join(process.cwd(), "src");
+// 許可リスト: ロックを取らなくて良い特殊ケース
+const ALLOWED_WITHOUT_LOCK = new Set([
+  // NSFW アニメはフルスクリーン遷移エフェクト。表示中はどのみち全画面を覆うため
+  // リサイズバーとの競合が発生しない。
+  "components/NSFWEyeAnimation.tsx",
+  // 記事一覧のレイアウト基盤で popup ではないが fixed overlay になっている等の
+  // 実質 popup でないケースは必要に応じてここに追加する。
+]);
+
+async function listTsxFiles(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const abs = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await listTsxFiles(abs)));
+    else if (entry.name.endsWith(".tsx") || entry.name.endsWith(".ts")) out.push(abs);
+  }
+  return out;
+}
+
+test.describe("popup-lock カバレッジ — fixed inset-0 モーダル網羅", () => {
+  test("fixed inset-0 z-5* を持つファイルは全て usePopupLock を呼んでいる", async () => {
+    const files = await listTsxFiles(SRC_DIR);
+    const offenders: string[] = [];
+    // usePopupLock / usePortalMenu を呼ぶと間接的にロックが立つ
+    const lockMarkers = ["usePopupLock", "usePortalMenu"];
+    for (const file of files) {
+      const content = await readFile(file, "utf-8");
+      const hasOverlay = /fixed inset-0[^"'`]*z-\[?5\d?\]?/.test(content);
+      if (!hasOverlay) continue;
+      const hasLock = lockMarkers.some((m) => content.includes(m));
+      const rel = file.replace(SRC_DIR + "/", "");
+      if (ALLOWED_WITHOUT_LOCK.has(rel)) continue;
+      if (!hasLock) offenders.push(rel);
+    }
+    expect(offenders, `ロック未取得のモーダル: ${offenders.join(", ")}`).toEqual([]);
+  });
+});

--- a/src/components/ArticleView.tsx
+++ b/src/components/ArticleView.tsx
@@ -22,6 +22,7 @@ import { useArticleContent } from "../hooks/useArticleContent";
 import { useArticleAi } from "../hooks/useArticleAi";
 import Spinner from "./Spinner";
 import { useImageDownload } from "../hooks/useImageDownload";
+import { usePopupLock } from "../hooks/usePopupLock";
 import { useContentLinkPreviews } from "../hooks/useContentLinkPreviews";
 import { useArticleNote } from "../hooks/useArticleNote";
 import { useArticleAiRatings } from "../hooks/useArticleAiRatings";
@@ -309,6 +310,9 @@ export default function ArticleView({
     confirmDownload,
     cancelDownload,
   } = useImageDownload(article, resolvedOgImage, contentRef, showToast);
+
+  // ダウンロード確認モーダル表示中はリサイズバーを無効化する（Issue #81）
+  usePopupLock(confirmingDownload);
 
   const embedInfo = article?.link ? extractEmbedInfo(article.link) : null;
 

--- a/src/components/article-view/ImageGallery.tsx
+++ b/src/components/article-view/ImageGallery.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from "react";
 import { useSyncedRef } from "../../hooks/useSyncedRef";
 import { useEventListener } from "../../hooks/useEventListener";
+import { usePopupLock } from "../../hooks/usePopupLock";
 
 interface Props {
   images: string[];
@@ -10,6 +11,9 @@ export default function ImageGallery({ images }: Props) {
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
   const lightboxTouchRef = useRef<number | null>(null);
   const lightboxRef = useSyncedRef({ lightboxIndex, imageCount: images.length });
+
+  // ライトボックス表示中はリサイズバーを無効化する（Issue #81）
+  usePopupLock(lightboxIndex !== null);
 
   useEventListener("keydown", (e) => {
     const { lightboxIndex: idx, imageCount } = lightboxRef.current;

--- a/src/components/article-view/SelectionExcludePopup.tsx
+++ b/src/components/article-view/SelectionExcludePopup.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import type { KeywordFilter } from "../../types";
+import { usePopupLock } from "../../hooks/usePopupLock";
 
 const MAX_SELECTION_LENGTH = 100;
 
@@ -86,6 +87,7 @@ export default function SelectionExcludePopup({
   showToast,
   onClose,
 }: Props) {
+  usePopupLock();
   const displayText = popup.text.length > 24 ? `${popup.text.slice(0, 24)}…` : popup.text;
 
   function doCopyQuote(e: { preventDefault: () => void }) {

--- a/src/lib/release-notes-data.ts
+++ b/src/lib/release-notes-data.ts
@@ -8,6 +8,8 @@ export const RELEASE_NOTES_MARKDOWN = `# リリースノート
 
 ### バグ修正
 
+- **幅調整バーのポップアップ対応漏れを追補** — Issue #81 の初版修正で拾えていなかった未ポートアル系のインラインモーダル（\`ArticleView\` の画像ダウンロード確認モーダル / \`ImageGallery\` の全画面ライトボックス / \`SelectionExcludePopup\`）にも \`usePopupLock\` を追加。さらに \`e2e/modal-popup-lock-coverage.spec.ts\` に静的検査テストを追加し、\`fixed inset-0 z-5*\` のフルスクリーンオーバーレイを持つコンポーネントは \`usePopupLock\` / \`usePortalMenu\` のいずれかを呼ぶことを CI で強制することで、今後のモーダル追加時の漏れを防ぐ（Issue #81 再発防止）。
+
 - **幅調整バーがポップアップ表示中も操作できる問題を修正** — 記事一覧 / フィード一覧 / 記事詳細の 3 ペイン境界にある幅調整バーが、モーダル・ドロップダウン表示中も pointer イベントを受けてドラッグできてしまい、オーバーレイより手前に見えてしまう不具合を修正（Issue #81）。\`src/lib/popup-lock.ts\` にグローバルなポップアップ表示数カウンタを追加し、\`src/hooks/usePopupLock.ts\`（\`usePopupLock(active?)\` / \`useHasOpenPopup()\`）を経由して登録・購読できるようにした。\`Modal\`（\`FeedDetailModal\` / \`FeedFilterModal\` / \`KeyboardShortcutsModal\` / \`ReadingStatsModal\` / \`ReleaseNotesModal\` / \`SnoozeModal\` が共通利用）、\`FeedQuickSwitchModal\`、\`usePortalMenu\`（\`FilterMenu\` / \`GlobalFilterMenu\` / \`ShareMenu\` / \`SnoozeMenu\` など）、および \`FeedItem\` のコンテキスト／ミュート／グループ移動メニューが表示中はロックを立てる。\`App.tsx\` のリサイズハンドルは \`useHasOpenPopup()\` を監視し、\`z-[5]\`（従来 \`z-20\`）へ引き下げたうえで表示中は \`pointer-events-none\` + \`opacity-0\` + \`aria-hidden\` を付与して操作不可にする。\`e2e/popup-lock.spec.ts\` にカウンタ増減・冪等性・通知購読の 6 ケースを追加。
 
 ### 新機能


### PR DESCRIPTION
## Summary
- Issue #81 に対するユーザーからの再報告（画像ダウンロード確認モーダル表示中にリサイズバーが残る）を修正
- 初版 PR #84 で捕捉できていなかった未ポートアル系インラインモーダルに `usePopupLock` を追加
  - `ArticleView` の画像ダウンロード確認モーダル（`confirmingDownload`）
  - `ImageGallery` の全画面ライトボックス（`lightboxIndex !== null`）
  - `SelectionExcludePopup`（常時）
- `e2e/modal-popup-lock-coverage.spec.ts` に静的検査を追加。`fixed inset-0 z-5*` のオーバーレイを持つファイルは `usePopupLock` / `usePortalMenu` のいずれかを呼んでいることを CI で強制し、今後の同種漏れを防ぐ

Closes #81

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run check` 通過
- [x] 新規静的検査テスト（modal-popup-lock-coverage）pass
- [x] popup-lock ユニットテスト 6 ケース pass
- [x] Playwright 全 811 ケース pass（pre-commit hook 経由）