### PR TITLE
バグ修正: x.com/twitter.com の OGP を vxtwitter.com 経由で取得 (Issue #89)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,8 @@
 
 ### バグ修正
 
+- **x.com / twitter.com の OGP を vxtwitter.com 経由で取得** — Twitter / X は bot 向けに OGP メタタグを返さないため、記事に該当 URL を含めても OGP プレビューが空になる不具合を修正（Issue #89）。`src/lib/ogp.ts` に `normalizeOgpFetchUrl(url)` を追加し、`x.com` / `www.x.com` / `mobile.x.com` / `twitter.com` / `www.twitter.com` / `mobile.twitter.com` を OGP 互換プロキシ `vxtwitter.com` に差し替えてから fetch する（hostname 完全一致で判定するため `x.com.evil.example` のような偽装ホストは対象外）。`fetchPageOgpMeta` 経由の呼び出し（`/api/ogp` / `/api/articles/save`）すべてに適用。置換対象・不正入力・他ホスト素通りを検証する 12 ケースを `e2e/ogp-url-normalize.spec.ts` に追加。
+
 - **コードハイライトが一瞬で外れる問題を修正** — `<pre><code>` に highlight.js で付与された `.hljs` class が、React の `dangerouslySetInnerHTML` 再代入や他の副作用 hook（`useContentLinkPreviews` 等）による DOM 書き換えで剥がれ、色付けが一瞬で消えてしまう不具合を修正（Issue #83）。`src/components/ArticleView.tsx` の `processedContent` を `useMemo` でメモ化し、`rawContent / embedInfo / theme` が変わらない限り同一文字列を返すようにして不要な innerHTML 再代入を抑止。さらに `src/hooks/useSyntaxHighlight.ts` に `MutationObserver` を追加し、コンテナ subtree 変更時は `pre code:not(.hljs)` を自動で再ハイライトするようにした。`hljs.highlightElement` 自身の mutation によるループを避けるため、適用時は observer を `disconnect → applyMissing → observe` でサンドイッチし、大量の DOM 変更時は `queueMicrotask` でバッチ化する。
 
 - **幅調整バーのポップアップ対応漏れを追補** — Issue #81 の初版修正で拾えていなかった未ポートアル系のインラインモーダル（`ArticleView` の画像ダウンロード確認モーダル / `ImageGallery` の全画面ライトボックス / `SelectionExcludePopup`）にも `usePopupLock` を追加。さらに `e2e/modal-popup-lock-coverage.spec.ts` に静的検査テストを追加し、`fixed inset-0 z-5*` のフルスクリーンオーバーレイを持つコンポーネントは `usePopupLock` / `usePortalMenu` のいずれかを呼ぶことを CI で強制することで、今後のモーダル追加時の漏れを防ぐ（Issue #81 再発防止）。

--- a/e2e/ogp-url-normalize.spec.ts
+++ b/e2e/ogp-url-normalize.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+import { normalizeOgpFetchUrl } from "../src/lib/ogp";
+
+/**
+ * normalizeOgpFetchUrl の回帰テスト。
+ * x.com / twitter.com 系ドメインは OGP を返さないため、
+ * vxtwitter.com に置き換えて取得する。
+ */
+
+test.describe("normalizeOgpFetchUrl — Twitter/X 系ホスト", () => {
+  test("x.com を vxtwitter.com に置換する", () => {
+    expect(normalizeOgpFetchUrl("https://x.com/user/status/123")).toBe(
+      "https://vxtwitter.com/user/status/123",
+    );
+  });
+
+  test("twitter.com を vxtwitter.com に置換する", () => {
+    expect(normalizeOgpFetchUrl("https://twitter.com/user/status/123")).toBe(
+      "https://vxtwitter.com/user/status/123",
+    );
+  });
+
+  test("www.x.com を vxtwitter.com に置換する", () => {
+    expect(normalizeOgpFetchUrl("https://www.x.com/user/status/123")).toBe(
+      "https://vxtwitter.com/user/status/123",
+    );
+  });
+
+  test("www.twitter.com を vxtwitter.com に置換する", () => {
+    expect(normalizeOgpFetchUrl("https://www.twitter.com/user/status/123")).toBe(
+      "https://vxtwitter.com/user/status/123",
+    );
+  });
+
+  test("mobile.twitter.com を vxtwitter.com に置換する", () => {
+    expect(normalizeOgpFetchUrl("https://mobile.twitter.com/user/status/123")).toBe(
+      "https://vxtwitter.com/user/status/123",
+    );
+  });
+
+  test("大文字ホスト名でも置換する", () => {
+    expect(normalizeOgpFetchUrl("https://X.COM/user/status/123")).toBe(
+      "https://vxtwitter.com/user/status/123",
+    );
+  });
+
+  test("クエリ文字列とフラグメントを保持する", () => {
+    expect(normalizeOgpFetchUrl("https://x.com/user/status/123?s=20#frag")).toBe(
+      "https://vxtwitter.com/user/status/123?s=20#frag",
+    );
+  });
+});
+
+test.describe("normalizeOgpFetchUrl — 他ホストは変更しない", () => {
+  test("example.com はそのまま返す", () => {
+    expect(normalizeOgpFetchUrl("https://example.com/page")).toBe("https://example.com/page");
+  });
+
+  test("x.com.example.com のような偽装ホストは変更しない", () => {
+    expect(normalizeOgpFetchUrl("https://x.com.evil.example/page")).toBe(
+      "https://x.com.evil.example/page",
+    );
+  });
+
+  test("vxtwitter.com 自体は変更しない", () => {
+    expect(normalizeOgpFetchUrl("https://vxtwitter.com/user/status/123")).toBe(
+      "https://vxtwitter.com/user/status/123",
+    );
+  });
+});
+
+test.describe("normalizeOgpFetchUrl — 不正入力", () => {
+  test("不正な URL はそのまま返す", () => {
+    expect(normalizeOgpFetchUrl("not a url")).toBe("not a url");
+  });
+
+  test("空文字はそのまま返す", () => {
+    expect(normalizeOgpFetchUrl("")).toBe("");
+  });
+});

--- a/src/lib/ogp.ts
+++ b/src/lib/ogp.ts
@@ -18,6 +18,35 @@ const FETCH_HEADERS = {
   "Accept-Language": "ja,en-US;q=0.9,en;q=0.8",
 };
 
+/** x.com / twitter.com は OGP を返さないため、代替ホスト vxtwitter.com に差し替える */
+const TWITTER_LIKE_HOSTS = new Set([
+  "x.com",
+  "www.x.com",
+  "mobile.x.com",
+  "twitter.com",
+  "www.twitter.com",
+  "mobile.twitter.com",
+]);
+
+/**
+ * OGP 取得用に URL を正規化する。
+ * x.com / twitter.com 系ホストは bot 向け OGP を返さないため、
+ * OGP 互換プロキシである vxtwitter.com に差し替える。
+ * 他ホスト・不正入力は変更せずそのまま返す。
+ */
+export function normalizeOgpFetchUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    if (TWITTER_LIKE_HOSTS.has(u.hostname.toLowerCase())) {
+      u.hostname = "vxtwitter.com";
+      return u.toString();
+    }
+    return url;
+  } catch {
+    return url;
+  }
+}
+
 /**
  * ページから取得した OGP メタデータ。
  * フェッチ失敗時は全フィールドが空文字のフォールバック値を返す。
@@ -41,7 +70,8 @@ export async function fetchPageOgpMeta(
   timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
 ): Promise<OgpMeta> {
   try {
-    const res = await fetchFollowSafeRedirects(url, { headers: FETCH_HEADERS }, timeoutMs);
+    const fetchUrl = normalizeOgpFetchUrl(url);
+    const res = await fetchFollowSafeRedirects(fetchUrl, { headers: FETCH_HEADERS }, timeoutMs);
     if (!res.ok || !res.body) return { title: "", description: "", image: "" };
 
     const bytes = await readBodyBytesPartial(res.body, MAX_BYTES);

--- a/src/lib/release-notes-data.ts
+++ b/src/lib/release-notes-data.ts
@@ -8,6 +8,8 @@ export const RELEASE_NOTES_MARKDOWN = `# リリースノート
 
 ### バグ修正
 
+- **x.com / twitter.com の OGP を vxtwitter.com 経由で取得** — Twitter / X は bot 向けに OGP メタタグを返さないため、記事に該当 URL を含めても OGP プレビューが空になる不具合を修正（Issue #89）。\`src/lib/ogp.ts\` に \`normalizeOgpFetchUrl(url)\` を追加し、\`x.com\` / \`www.x.com\` / \`mobile.x.com\` / \`twitter.com\` / \`www.twitter.com\` / \`mobile.twitter.com\` を OGP 互換プロキシ \`vxtwitter.com\` に差し替えてから fetch する（hostname 完全一致で判定するため \`x.com.evil.example\` のような偽装ホストは対象外）。\`fetchPageOgpMeta\` 経由の呼び出し（\`/api/ogp\` / \`/api/articles/save\`）すべてに適用。置換対象・不正入力・他ホスト素通りを検証する 12 ケースを \`e2e/ogp-url-normalize.spec.ts\` に追加。
+
 - **コードハイライトが一瞬で外れる問題を修正** — \`<pre><code>\` に highlight.js で付与された \`.hljs\` class が、React の \`dangerouslySetInnerHTML\` 再代入や他の副作用 hook（\`useContentLinkPreviews\` 等）による DOM 書き換えで剥がれ、色付けが一瞬で消えてしまう不具合を修正（Issue #83）。\`src/components/ArticleView.tsx\` の \`processedContent\` を \`useMemo\` でメモ化し、\`rawContent / embedInfo / theme\` が変わらない限り同一文字列を返すようにして不要な innerHTML 再代入を抑止。さらに \`src/hooks/useSyntaxHighlight.ts\` に \`MutationObserver\` を追加し、コンテナ subtree 変更時は \`pre code:not(.hljs)\` を自動で再ハイライトするようにした。\`hljs.highlightElement\` 自身の mutation によるループを避けるため、適用時は observer を \`disconnect → applyMissing → observe\` でサンドイッチし、大量の DOM 変更時は \`queueMicrotask\` でバッチ化する。
 
 - **幅調整バーのポップアップ対応漏れを追補** — Issue #81 の初版修正で拾えていなかった未ポートアル系のインラインモーダル（\`ArticleView\` の画像ダウンロード確認モーダル / \`ImageGallery\` の全画面ライトボックス / \`SelectionExcludePopup\`）にも \`usePopupLock\` を追加。さらに \`e2e/modal-popup-lock-coverage.spec.ts\` に静的検査テストを追加し、\`fixed inset-0 z-5*\` のフルスクリーンオーバーレイを持つコンポーネントは \`usePopupLock\` / \`usePortalMenu\` のいずれかを呼ぶことを CI で強制することで、今後のモーダル追加時の漏れを防ぐ（Issue #81 再発防止）。


### PR DESCRIPTION
## Summary

- x.com / twitter.com は bot 向けに OGP メタタグを返さないため、記事内に該当 URL を含めても OGP プレビューが空になっていた問題を修正（Issue #89）
- `src/lib/ogp.ts` に `normalizeOgpFetchUrl()` を追加し、`fetchPageOgpMeta()` 内で URL を変換してから fetch
- 対象ホスト: `x.com` / `www.x.com` / `mobile.x.com` / `twitter.com` / `www.twitter.com` / `mobile.twitter.com`（hostname 完全一致判定で偽装ホストは対象外）

## Test plan

- [x] `npm run check` (lint/format)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `e2e/ogp-url-normalize.spec.ts` 12 ケース全通過
- [x] `npm run test:e2e` 823 ケース全通過

Closes #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Open Graph previews displaying as empty when sharing Twitter/X links (Issue #89)

* **Tests**
  * Added 12 end-to-end test cases validating URL normalization and edge case scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->