### PR TITLE
新機能: コンテンツ幅に wide (900px) を追加 (Issue #80)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ## 2026-04-18
 
+### 新機能
+
+- **コンテンツ幅に `wide` (900px) を追加** — 記事詳細の領域幅を広げても（フォーカスモード起動や 3 ペイン境界のリサイズ時）本文の `maxWidth` が `narrow:640px` / `medium:720px` / `full:none` の 3 段階しかなく、`medium` から `full` へ飛ぶと急激に全幅まで広がってしまい中間帯を選びづらい問題を解消（Issue #80）。`src/lib/reader-settings.ts` の `ContentWidth` に `wide` を追加し、サイクル順を `narrow → medium → wide → full → narrow` に拡張。ラベル表示（ArticleView の幅トグルボタン）も `900` に対応。`e2e/reader-settings.spec.ts` の `CONTENT_WIDTH_CYCLE` 長さアサートを 3 → 4 に更新。
+
 ### バグ修正
 
 - **Zenn 記事の埋め込み URL が消える問題を修正** — Zenn 本文中の `<span class="zenn-embedded zenn-embedded-card|tweet|mermaid">` が Readability に「本文外」と判定されて span ごと削除され、`postProcess` 内の `transformZennLinkEmbeds` / `transformZennMermaidEmbeds` が走る前に消えてしまう不具合を修正（Issue #88）。`src/lib/content.ts` の `extractMainContent` で `extractWithReadability` 実行前に Zenn 埋め込み変換を適用し、Readability 通過時には iframe を含まない `<p><a>` / `<pre><code>` 形式になっているため、本文判定ロジックが要素を保持するようになった。`postProcess` 側の同変換は冪等なため regex フォールバック経路の安全網として残している。`e2e/content-extraction.spec.ts` に Readability 経由でも card / tweet / mermaid 埋め込みが本文に保持されることを検証する 3 ケースを追加。

--- a/e2e/reader-settings.spec.ts
+++ b/e2e/reader-settings.spec.ts
@@ -85,8 +85,8 @@ test.describe("LINE_HEIGHT_CYCLE — 行間設定", () => {
 // ===== コンテンツ幅 =====
 
 test.describe("CONTENT_WIDTH_CYCLE — コンテンツ幅設定", () => {
-  test("3段階の幅定数を持つ", () => {
-    expect(CONTENT_WIDTH_CYCLE).toHaveLength(3);
+  test("4段階の幅定数を持つ", () => {
+    expect(CONTENT_WIDTH_CYCLE).toHaveLength(4);
   });
 
   test("getContentWidthStyle が maxWidth を返す", () => {

--- a/src/lib/reader-settings.ts
+++ b/src/lib/reader-settings.ts
@@ -1,7 +1,7 @@
 /**
  * リーダー表示設定ユーティリティ
  *
- * フォントサイズ (6段階) / 行間 (5段階) / コンテンツ幅 (3段階) の
+ * フォントサイズ (6段階) / 行間 (5段階) / コンテンツ幅 (4段階) の
  * 定数・CSS スタイル生成・サイクル関数を提供する。
  */
 
@@ -77,19 +77,21 @@ export function cycleLineHeight(current: LineHeight): LineHeight {
 
 // ===== コンテンツ幅 =====
 
-export type ContentWidth = "narrow" | "medium" | "full";
+export type ContentWidth = "narrow" | "medium" | "wide" | "full";
 
-export const CONTENT_WIDTH_CYCLE: ContentWidth[] = ["narrow", "medium", "full"];
+export const CONTENT_WIDTH_CYCLE: ContentWidth[] = ["narrow", "medium", "wide", "full"];
 
 const CONTENT_WIDTH_VALUES: Record<ContentWidth, string> = {
   narrow: "640px",
   medium: "720px",
+  wide: "900px",
   full: "none",
 };
 
 export const CONTENT_WIDTH_LABELS: Record<ContentWidth, string> = {
   narrow: "640",
   medium: "720",
+  wide: "900",
   full: "全幅",
 };
 

--- a/src/lib/release-notes-data.ts
+++ b/src/lib/release-notes-data.ts
@@ -6,6 +6,10 @@ export const RELEASE_NOTES_MARKDOWN = `# リリースノート
 
 ## 2026-04-18
 
+### 新機能
+
+- **コンテンツ幅に \`wide\` (900px) を追加** — 記事詳細の領域幅を広げても（フォーカスモード起動や 3 ペイン境界のリサイズ時）本文の \`maxWidth\` が \`narrow:640px\` / \`medium:720px\` / \`full:none\` の 3 段階しかなく、\`medium\` から \`full\` へ飛ぶと急激に全幅まで広がってしまい中間帯を選びづらい問題を解消（Issue #80）。\`src/lib/reader-settings.ts\` の \`ContentWidth\` に \`wide\` を追加し、サイクル順を \`narrow → medium → wide → full → narrow\` に拡張。ラベル表示（ArticleView の幅トグルボタン）も \`900\` に対応。\`e2e/reader-settings.spec.ts\` の \`CONTENT_WIDTH_CYCLE\` 長さアサートを 3 → 4 に更新。
+
 ### バグ修正
 
 - **Zenn 記事の埋め込み URL が消える問題を修正** — Zenn 本文中の \`<span class="zenn-embedded zenn-embedded-card|tweet|mermaid">\` が Readability に「本文外」と判定されて span ごと削除され、\`postProcess\` 内の \`transformZennLinkEmbeds\` / \`transformZennMermaidEmbeds\` が走る前に消えてしまう不具合を修正（Issue #88）。\`src/lib/content.ts\` の \`extractMainContent\` で \`extractWithReadability\` 実行前に Zenn 埋め込み変換を適用し、Readability 通過時には iframe を含まない \`<p><a>\` / \`<pre><code>\` 形式になっているため、本文判定ロジックが要素を保持するようになった。\`postProcess\` 側の同変換は冪等なため regex フォールバック経路の安全網として残している。\`e2e/content-extraction.spec.ts\` に Readability 経由でも card / tweet / mermaid 埋め込みが本文に保持されることを検証する 3 ケースを追加。


### PR DESCRIPTION
## Summary

- `ContentWidth` に `wide` (900px) を追加し、記事詳細のコンテンツ幅選択を 3 → 4 段階に拡張
- サイクル順: `narrow(640) → medium(720) → wide(900) → full(none) → narrow`
- Issue #80 の「領域を広げた時にコンテンツ幅が medium と full の間で飛びすぎる」問題を解消

## 変更ファイル

- `src/lib/reader-settings.ts` — `ContentWidth` 型 / `CONTENT_WIDTH_CYCLE` / `CONTENT_WIDTH_VALUES` / `CONTENT_WIDTH_LABELS` に `wide` を追加
- `e2e/reader-settings.spec.ts` — 長さアサートを 3 → 4 に更新
- `RELEASE_NOTES.md` / `src/lib/release-notes-data.ts` — リリースノート追記

## Test plan

- [x] `npm run check` pass
- [x] `npm run typecheck` pass
- [x] `npx playwright test e2e/reader-settings.spec.ts` pass (15/15)
- [x] pre-commit hook pass

Closes #80