### PR TITLE
新機能: 全フィード横断のフルテキスト検索と高度フィルタリング (#102)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 ### 新機能
 
+- **全フィード横断のフルテキスト検索と高度フィルタリング** — Issue #102。検索ボックスに高度クエリ構文を追加：フィールド指定 (`title:foo` / `author:bar` / `feed:baz` / `category:qux` / `content:hello`)、フレーズ検索 (`"hello world"`)、否定 (`-foo`)、暗黙 AND・明示 OR (`foo OR bar`)、大文字小文字無視。構文を含まない単純クエリは従来通り title / summary / author / categories / content を横断する既存互換挙動。`src/lib/full-text-search.ts` に純粋関数 (`parseSearchQuery` / `matchesAdvancedQuery`) として実装し、`src/lib/article-filter.ts` の `buildQueryPredicate` から呼び出す。`SearchContext.feedTitleByHash` を `useFilteredArticles` 側で構築し `feed:` クエリを解決可能に。検索条件の保存機能 (`useFullTextSearch` フック) を新設、`localStorage` (`rss-saved-searches`) に最大 20 件まで保存し検索ドロップダウンの「保存済み」セクションから即時呼び出せる。検索バー右側に「保存」ボタンを追加 (2 文字以上の入力時のみ表示)。`e2e/full-text-search.spec.ts` に 42 ケース追加 (parseSearchQuery / matchesAdvancedQuery のフィールド・OR/AND/NOT・フレーズ・エッジケース・未閉鎖クォート fallback・OR の大小無視)。
 - **フィードビュータブ + Pinterest 風ギャラリーレイアウト** — Issue #114。サイドバー上部に「記事 / 画像 / 動画 / SNS」の 4 タブを追加し、各フィードを任意のカテゴリに分類できるようにした。タブ切替で対応する view のフィードのみが表示される（未分類フィードは「記事」タブ所属扱い）。併せて `gallery` レイアウトを新設（CSS columns による masonry、サムネイル優先）。`UserSubscription.view` / `Feed.view` / `FeedPatchPayload.view` を追加し、`PATCH /api/feeds/:id` で `view: "articles" | "pictures" | "videos" | "social" | null` を受け付ける。`FeedItem` のコンテキストメニューに「表示カテゴリ」サブメニューを追加。localStorage キー `rss-active-feed-view` にタブ選択状態を永続化。UX は [Folo](https://github.com/RSSNext/Folo)（AGPL-3.0）を参考にしたがコードは流用せず MIT のままとした。
 
 ### バグ修正

--- a/e2e/full-text-search.spec.ts
+++ b/e2e/full-text-search.spec.ts
@@ -1,0 +1,234 @@
+import { test, expect } from "@playwright/test";
+import {
+  parseSearchQuery,
+  matchesAdvancedQuery,
+  type SearchContext,
+} from "../src/lib/full-text-search";
+
+const BASE = {
+  id: "a1",
+  feedHash: "feed-hash-1",
+  title: "TypeScript で始める関数型プログラミング",
+  summary: "モナドとファンクターの使い方を解説します。",
+  content: "<p>圏論の入り口となる Functor / Monad について本文で詳しく扱います。</p>",
+  author: "山田 太郎",
+  categories: ["TypeScript", "関数型", "プログラミング"],
+  link: "https://example.com/a1",
+  publishedAt: "2026-04-01T00:00:00.000Z",
+  createdAt: "2026-04-01T00:00:00.000Z",
+  guid: "g1",
+};
+
+const CTX: SearchContext = {
+  feedTitleByHash: new Map([
+    ["feed-hash-1", "Zenn Trend"],
+    ["feed-hash-2", "DevelopersIO"],
+  ]),
+};
+
+test.describe("parseSearchQuery — 基本", () => {
+  test("空クエリは null", () => {
+    expect(parseSearchQuery("")).toBeNull();
+    expect(parseSearchQuery("   ")).toBeNull();
+  });
+
+  test("単一語は TERM", () => {
+    const ast = parseSearchQuery("TypeScript");
+    expect(ast?.kind).toBe("TERM");
+  });
+
+  test("空白区切りは AND", () => {
+    const ast = parseSearchQuery("foo bar");
+    expect(ast?.kind).toBe("AND");
+  });
+
+  test("OR キーワードで OR ノード", () => {
+    const ast = parseSearchQuery("foo OR bar");
+    expect(ast?.kind).toBe("OR");
+  });
+
+  test("フィールド指定 title:foo は TERM with field", () => {
+    const ast = parseSearchQuery("title:foo");
+    expect(ast).toEqual({ kind: "TERM", field: "title", value: "foo" });
+  });
+
+  test("否定 -foo は NOT", () => {
+    const ast = parseSearchQuery("-foo");
+    expect(ast?.kind).toBe("NOT");
+  });
+
+  test('フレーズ "hello world" は単一 TERM', () => {
+    const ast = parseSearchQuery('"hello world"');
+    expect(ast).toEqual({ kind: "TERM", value: "hello world" });
+  });
+
+  test("複合: title:foo OR author:bar", () => {
+    const ast = parseSearchQuery("title:foo OR author:bar");
+    expect(ast?.kind).toBe("OR");
+  });
+});
+
+test.describe("matchesAdvancedQuery — 既存互換 (構文無し)", () => {
+  test("空クエリは true", () => {
+    expect(matchesAdvancedQuery(BASE, "", CTX)).toBe(true);
+  });
+
+  test("タイトル単語にマッチ", () => {
+    expect(matchesAdvancedQuery(BASE, "TypeScript", CTX)).toBe(true);
+  });
+
+  test("サマリーにマッチ", () => {
+    expect(matchesAdvancedQuery(BASE, "モナド", CTX)).toBe(true);
+  });
+
+  test("本文 (content) もマッチ対象", () => {
+    expect(matchesAdvancedQuery(BASE, "圏論", CTX)).toBe(true);
+  });
+
+  test("content 内の HTML タグはマッチしない", () => {
+    expect(matchesAdvancedQuery(BASE, "<p>", CTX)).toBe(false);
+  });
+
+  test("author にマッチ", () => {
+    expect(matchesAdvancedQuery(BASE, "山田", CTX)).toBe(true);
+  });
+
+  test("category にマッチ", () => {
+    expect(matchesAdvancedQuery(BASE, "関数型", CTX)).toBe(true);
+  });
+
+  test("マッチしない単語は false", () => {
+    expect(matchesAdvancedQuery(BASE, "Rust", CTX)).toBe(false);
+  });
+
+  test("AND: 全語マッチで true", () => {
+    expect(matchesAdvancedQuery(BASE, "TypeScript モナド", CTX)).toBe(true);
+  });
+
+  test("AND: 1 語ミスマッチで false", () => {
+    expect(matchesAdvancedQuery(BASE, "TypeScript Rust", CTX)).toBe(false);
+  });
+
+  test("大文字小文字を無視", () => {
+    expect(matchesAdvancedQuery(BASE, "typescript", CTX)).toBe(true);
+  });
+});
+
+test.describe("matchesAdvancedQuery — フィールド指定", () => {
+  test("title:TypeScript はタイトルにのみマッチ", () => {
+    expect(matchesAdvancedQuery(BASE, "title:TypeScript", CTX)).toBe(true);
+    expect(matchesAdvancedQuery(BASE, "title:モナド", CTX)).toBe(false);
+  });
+
+  test("author:山田 は著者にのみマッチ", () => {
+    expect(matchesAdvancedQuery(BASE, "author:山田", CTX)).toBe(true);
+    expect(matchesAdvancedQuery(BASE, "author:TypeScript", CTX)).toBe(false);
+  });
+
+  test("category:関数型 はカテゴリにのみマッチ", () => {
+    expect(matchesAdvancedQuery(BASE, "category:関数型", CTX)).toBe(true);
+    expect(matchesAdvancedQuery(BASE, "category:山田", CTX)).toBe(false);
+  });
+
+  test("feed:Zenn はフィード名にマッチ", () => {
+    expect(matchesAdvancedQuery(BASE, "feed:Zenn", CTX)).toBe(true);
+    expect(matchesAdvancedQuery(BASE, "feed:DevelopersIO", CTX)).toBe(false);
+  });
+
+  test("content:圏論 は本文にのみマッチ", () => {
+    expect(matchesAdvancedQuery(BASE, "content:圏論", CTX)).toBe(true);
+    expect(matchesAdvancedQuery(BASE, "content:TypeScript", CTX)).toBe(false);
+  });
+
+  test("不明なフィールドは普通の語として扱う", () => {
+    // 'foo:bar' のような不明な接頭辞は、既存検索で 'foo:bar' という文字列を探す
+    expect(matchesAdvancedQuery(BASE, "foo:bar", CTX)).toBe(false);
+  });
+});
+
+test.describe("matchesAdvancedQuery — OR / AND / NOT", () => {
+  test("OR: どちらか一方マッチで true", () => {
+    expect(matchesAdvancedQuery(BASE, "Rust OR TypeScript", CTX)).toBe(true);
+  });
+
+  test("OR: 両方ミスで false", () => {
+    expect(matchesAdvancedQuery(BASE, "Rust OR Java", CTX)).toBe(false);
+  });
+
+  test("否定: -Rust は true (Rust は含まない)", () => {
+    expect(matchesAdvancedQuery(BASE, "-Rust", CTX)).toBe(true);
+  });
+
+  test("否定: -TypeScript は false", () => {
+    expect(matchesAdvancedQuery(BASE, "-TypeScript", CTX)).toBe(false);
+  });
+
+  test("AND + NOT 組合せ: TypeScript -Rust", () => {
+    expect(matchesAdvancedQuery(BASE, "TypeScript -Rust", CTX)).toBe(true);
+    expect(matchesAdvancedQuery(BASE, "TypeScript -モナド", CTX)).toBe(false);
+  });
+
+  test("OR は AND より優先度が低い: A B OR C は (A AND B) OR C", () => {
+    // TypeScript モナド OR Rust → (TypeScript AND モナド) OR Rust → true
+    expect(matchesAdvancedQuery(BASE, "TypeScript モナド OR Rust", CTX)).toBe(true);
+    // Rust モナド OR TypeScript → (Rust AND モナド) OR TypeScript → true
+    expect(matchesAdvancedQuery(BASE, "Rust モナド OR TypeScript", CTX)).toBe(true);
+    // Rust モナド OR Java → false
+    expect(matchesAdvancedQuery(BASE, "Rust モナド OR Java", CTX)).toBe(false);
+  });
+});
+
+test.describe("matchesAdvancedQuery — フレーズ検索", () => {
+  test('"山田 太郎" はフルネームでマッチ', () => {
+    expect(matchesAdvancedQuery(BASE, '"山田 太郎"', CTX)).toBe(true);
+  });
+
+  test('"太郎 山田" は順序が違うのでマッチしない', () => {
+    expect(matchesAdvancedQuery(BASE, '"太郎 山田"', CTX)).toBe(false);
+  });
+
+  test("フィールド指定 + フレーズ", () => {
+    expect(matchesAdvancedQuery(BASE, 'title:"始める関数型"', CTX)).toBe(true);
+  });
+});
+
+test.describe("matchesAdvancedQuery — エッジケース", () => {
+  test("author 未定義でもクラッシュしない", () => {
+    const a = { ...BASE, author: undefined };
+    expect(matchesAdvancedQuery(a, "author:山田", CTX)).toBe(false);
+  });
+
+  test("content 未定義でもクラッシュしない", () => {
+    const a = { ...BASE, content: undefined };
+    expect(matchesAdvancedQuery(a, "content:圏論", CTX)).toBe(false);
+  });
+
+  test("categories 未定義でもクラッシュしない", () => {
+    const a = { ...BASE, categories: undefined };
+    expect(matchesAdvancedQuery(a, "category:関数型", CTX)).toBe(false);
+  });
+
+  test("不明な feedHash でも feed: クエリでクラッシュしない", () => {
+    const a = { ...BASE, feedHash: "unknown" };
+    expect(matchesAdvancedQuery(a, "feed:Zenn", CTX)).toBe(false);
+  });
+
+  test("未閉鎖クォートは閉じたものとして扱う", () => {
+    expect(matchesAdvancedQuery(BASE, '"TypeScript', CTX)).toBe(true);
+    expect(matchesAdvancedQuery(BASE, 'title:"TypeScript', CTX)).toBe(true);
+  });
+
+  test("OR の大小を無視する", () => {
+    expect(matchesAdvancedQuery(BASE, "Rust or TypeScript", CTX)).toBe(true);
+    expect(matchesAdvancedQuery(BASE, "Rust Or TypeScript", CTX)).toBe(true);
+    expect(matchesAdvancedQuery(BASE, "Rust oR TypeScript", CTX)).toBe(true);
+  });
+
+  test("ダッシュ - 単独はトークンとして無視", () => {
+    expect(parseSearchQuery("-")).toBeNull();
+  });
+
+  test("title: 単体（値なし）はトークンとして無視", () => {
+    expect(parseSearchQuery("title:")).toBeNull();
+  });
+});

--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -17,6 +17,7 @@ import { SHORTCUT_MAP } from "../config/shortcuts";
 import FeedFilterModal from "./FeedFilterModal";
 import { useOgpCache } from "../hooks/useOgpCache";
 import { useSearchHistory } from "../hooks/useSearchHistory";
+import { useFullTextSearch } from "../hooks/useFullTextSearch";
 import { useSyncedRef } from "../hooks/useSyncedRef";
 import { SPECIAL_FEED_IDS } from "../lib/storage";
 import { isArticleRead } from "../lib/article-filter";
@@ -269,6 +270,9 @@ export default function ArticleList({
   const { history, addToHistory, removeFromHistory } = useSearchHistory();
   const [showHistory, setShowHistory] = useState(false);
   const searchContainerRef = useRef<HTMLDivElement>(null);
+
+  // 保存検索 (Issue #102) — 高度クエリ構文と組み合わせて再利用
+  const { savedSearches, save: saveSearch, removeSaved } = useFullTextSearch();
 
   // フォーカスが検索コンテナ外に移ったら履歴を閉じる
   const handleSearchBlur = useCallback((e: React.FocusEvent) => {
@@ -719,17 +723,93 @@ export default function ArticleList({
           <input
             ref={searchRef}
             type="search"
-            placeholder="検索... (/ でフォーカス)"
+            placeholder="検索... (/ でフォーカス、title:foo OR -bar 等)"
             value={rawQuery}
             onChange={(e) => updateQuery(e.target.value)}
             onKeyDown={handleSearchKeyDown}
             onFocus={() => {
-              if (history.length > 0) setShowHistory(true);
+              if (history.length > 0 || savedSearches.length > 0) setShowHistory(true);
             }}
-            className="w-full text-[12px] bg-surface-base border border-border-default rounded-lg px-2.5 py-1.5 text-text-strong placeholder-text-faint outline-none focus:border-text-muted transition-colors duration-200"
+            className="w-full text-[12px] bg-surface-base border border-border-default rounded-lg pl-2.5 pr-9 py-1.5 text-text-strong placeholder-text-faint outline-none focus:border-text-muted transition-colors duration-200"
           />
-          {showHistory && history.length > 0 && (
-            <div className="absolute z-20 left-0 right-0 mt-1 bg-surface-elevated border border-border-default rounded-lg shadow-lg overflow-hidden">
+          {rawQuery.trim().length >= 2 && (
+            <button
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                const name = window.prompt("保存名を入力してください", rawQuery.trim());
+                if (name && name.trim()) saveSearch(name, rawQuery.trim());
+              }}
+              className="absolute right-5 top-1/2 -translate-y-1/2 text-[10px] text-text-muted hover:text-text-strong transition-colors px-1.5 py-0.5"
+              title="この検索条件を保存"
+            >
+              保存
+            </button>
+          )}
+          {showHistory && (savedSearches.length > 0 || history.length > 0) && (
+            <div className="absolute z-20 left-0 right-0 mt-1 bg-surface-elevated border border-border-default rounded-lg shadow-lg overflow-hidden max-h-80 overflow-y-auto">
+              {savedSearches.length > 0 && (
+                <>
+                  <div className="px-2.5 pt-1.5 pb-1 text-[10px] font-medium tracking-[0.25em] uppercase text-text-muted">
+                    保存済み
+                  </div>
+                  {savedSearches.map((s) => (
+                    <div
+                      key={s.id}
+                      className="flex items-center justify-between px-2.5 py-1.5 hover:bg-surface-hover cursor-pointer group"
+                    >
+                      <button
+                        className="flex items-center gap-1.5 flex-1 min-w-0 text-left"
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          applyHistoryItem(s.query);
+                        }}
+                        title={s.query}
+                      >
+                        <svg
+                          width="10"
+                          height="10"
+                          viewBox="0 0 12 12"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.6"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          className="text-bookmark flex-shrink-0"
+                        >
+                          <path d="M3 1.5h6v9l-3-2-3 2z" />
+                        </svg>
+                        <span className="text-[11px] text-text-default truncate">{s.name}</span>
+                      </button>
+                      <button
+                        className="opacity-0 group-hover:opacity-100 w-4 h-4 flex items-center justify-center rounded text-text-faint hover:text-text-muted transition-opacity flex-shrink-0"
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          removeSaved(s.id);
+                        }}
+                        title="保存検索を削除"
+                      >
+                        <svg
+                          width="8"
+                          height="8"
+                          viewBox="0 0 8 8"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.6"
+                          strokeLinecap="round"
+                        >
+                          <path d="M1 1l6 6M7 1L1 7" />
+                        </svg>
+                      </button>
+                    </div>
+                  ))}
+                  {history.length > 0 && (
+                    <div className="border-t border-border-subtle mt-1 px-2.5 pt-1.5 pb-1 text-[10px] font-medium tracking-[0.25em] uppercase text-text-muted">
+                      履歴
+                    </div>
+                  )}
+                </>
+              )}
               {history.map((q) => (
                 <div
                   key={q}

--- a/src/hooks/useFilteredArticles.ts
+++ b/src/hooks/useFilteredArticles.ts
@@ -287,6 +287,11 @@ export function useFilteredArticles({
       new Map(feeds.filter((f) => f.category).map((f) => [f.id, f.category!] as [string, string])),
     [feeds],
   );
+  // feedHash → タイトルのマップ（高度クエリ feed: 検索で使用）
+  const feedTitleByHash = useMemo(
+    () => new Map(feeds.map((f) => [f.id, f.title] as [string, string])),
+    [feeds],
+  );
   // globalFilter の正規化（キーワード文字列 → CompiledKeywordFilter への変換）を useMemo でキャッシュ。
   // filterAndSortArticles は全記事をループする hot path のため、正規表現コンパイルをループ外に出すことで
   // 記事ごとの不要な RegExp 生成を回避する。feedFilterMap と同じ戦略（変更時のみ再ビルド）。
@@ -328,6 +333,7 @@ export function useFilteredArticles({
         feedCategoryMap,
         digestMode,
         groupFeedIds,
+        feedTitleByHash,
       }),
     [
       articles,
@@ -361,6 +367,7 @@ export function useFilteredArticles({
       feedCategoryMap,
       digestMode,
       groupFeedIds,
+      feedTitleByHash,
     ],
   );
 

--- a/src/hooks/useFullTextSearch.ts
+++ b/src/hooks/useFullTextSearch.ts
@@ -1,0 +1,63 @@
+import { useCallback } from "react";
+import { STORAGE_KEYS } from "../lib/storage";
+import { useLocalStorageHistory } from "./useLocalStorageHistory";
+
+const MAX_SAVED = 20;
+
+export interface SavedSearch {
+  /** 安定 ID (crypto.randomUUID) */
+  id: string;
+  /** 表示名（ユーザー入力） */
+  name: string;
+  /** 検索クエリ文字列（高度クエリ構文を含む） */
+  query: string;
+  /** 保存日時 (ISO 8601) */
+  createdAt: string;
+}
+
+/**
+ * 全フィード横断のフルテキスト検索 — 保存検索条件管理 (Issue #102)。
+ *
+ * - localStorage に保存して再ログイン後も維持
+ * - 同名で保存すると上書き（先頭に移動）
+ * - 上限 MAX_SAVED 件
+ *
+ * 検索式自体のパース・評価は `src/lib/full-text-search.ts` を参照。
+ */
+export function useFullTextSearch() {
+  const {
+    items: savedSearches,
+    prepend,
+    remove,
+    clear,
+  } = useLocalStorageHistory<SavedSearch>(STORAGE_KEYS.SAVED_SEARCHES, MAX_SAVED);
+
+  const save = useCallback(
+    (name: string, query: string) => {
+      const trimmedName = name.trim();
+      const trimmedQuery = query.trim();
+      if (!trimmedName || !trimmedQuery) return;
+      const entry: SavedSearch = {
+        id:
+          typeof crypto !== "undefined" && "randomUUID" in crypto
+            ? crypto.randomUUID()
+            : `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        name: trimmedName,
+        query: trimmedQuery,
+        createdAt: new Date().toISOString(),
+      };
+      // 同名は上書き (= 既存を消して先頭に追加)
+      prepend(entry, (s) => s.name);
+    },
+    [prepend],
+  );
+
+  const removeSaved = useCallback(
+    (id: string) => {
+      remove((s) => s.id === id);
+    },
+    [remove],
+  );
+
+  return { savedSearches, save, removeSaved, clearSaved: clear };
+}

--- a/src/lib/article-filter.ts
+++ b/src/lib/article-filter.ts
@@ -1,7 +1,11 @@
 import type { Article, DateRange, ReadingTimeRange } from "../types";
 import { type CompiledKeywordFilter, matchesKeywordFilter } from "./keyword-filter";
-import { articleMatchesQuery, getDateRangeStart, readingTime } from "./article-utils";
+import { getDateRangeStart, readingTime } from "./article-utils";
+import { matchesAdvancedQuery, type SearchContext } from "./full-text-search";
 import { SPECIAL_FEED_IDS } from "./storage";
+
+/** 空の feedTitleByHash — feed: クエリ未対応時のデフォルト */
+const EMPTY_FEED_TITLE_MAP: ReadonlyMap<string, string> = new Map();
 
 /**
  * 記事が既読かどうかを判定する。
@@ -59,6 +63,8 @@ export interface ArticleFilterOptions {
   digestMode?: boolean;
   /** グループ選択時の対象フィード ID セット — 設定時は feedHash が含まれる記事のみ表示 */
   groupFeedIds?: Set<string>;
+  /** feedHash → フィード表示名のマップ — `feed:` クエリで使用（未指定時は feed: クエリは常にミス） */
+  feedTitleByHash?: ReadonlyMap<string, string>;
 }
 
 /**
@@ -216,9 +222,10 @@ function buildReadingTimePredicate(opts: ArticleFilterOptions): ((a: Article) =>
 
 /** 検索クエリ述語（activeIds に関わらず常に適用） */
 function buildQueryPredicate(opts: ArticleFilterOptions): ((a: Article) => boolean) | null {
-  const q = opts.query.trim().toLowerCase();
+  const q = opts.query.trim();
   if (!q) return null;
-  return (a) => articleMatchesQuery(a, q);
+  const ctx: SearchContext = { feedTitleByHash: opts.feedTitleByHash ?? EMPTY_FEED_TITLE_MAP };
+  return (a) => matchesAdvancedQuery(a, q, ctx);
 }
 
 /** 日付範囲述語（activeIds に関わらず常に適用） */

--- a/src/lib/full-text-search.ts
+++ b/src/lib/full-text-search.ts
@@ -1,0 +1,246 @@
+/**
+ * 全フィード横断のフルテキスト検索 (Issue #102)
+ *
+ * - フィールド指定: title:foo / author:bar / feed:baz / category:qux / content:hello
+ * - フレーズ検索: "hello world"
+ * - 否定: -foo / -title:foo
+ * - 暗黙 AND, 明示 OR ("foo OR bar")
+ * - 大文字小文字無視
+ * - 構文を含まない単純クエリは title / summary / author / categories / content を横断 (既存互換)
+ */
+
+export type SearchField = "title" | "author" | "feed" | "category" | "content";
+
+const FIELD_NAMES: ReadonlySet<SearchField> = new Set([
+  "title",
+  "author",
+  "feed",
+  "category",
+  "content",
+]);
+
+export type SearchNode =
+  | { kind: "TERM"; field?: SearchField; value: string }
+  | { kind: "NOT"; child: SearchNode }
+  | { kind: "AND"; children: SearchNode[] }
+  | { kind: "OR"; children: SearchNode[] };
+
+export interface SearchableArticle {
+  feedHash: string;
+  title: string;
+  summary: string;
+  content?: string;
+  author?: string;
+  categories?: string[];
+}
+
+export interface SearchContext {
+  /** feedHash → フィード表示名 (feed: 検索に使用) */
+  feedTitleByHash: ReadonlyMap<string, string>;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                  Tokenizer                                 */
+/* -------------------------------------------------------------------------- */
+
+interface Token {
+  /** 元の文字列。`title:foo` や `"hello world"` を含む 1 つの単位 */
+  text: string;
+}
+
+/**
+ * クエリ文字列をトークン化する。
+ *
+ * - フレーズ ("..."): クォートで囲まれた範囲を 1 トークン。クォート前にフィールド指定 (title:) が
+ *   付く場合はそれを保持する: title:"foo bar" → text='title:"foo bar"'
+ * - それ以外: 空白区切り
+ */
+function tokenize(query: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  const n = query.length;
+  while (i < n) {
+    // 空白スキップ
+    while (i < n && /\s/.test(query[i]!)) i++;
+    if (i >= n) break;
+
+    let start = i;
+    // フィールド接頭辞 (title:, content: 等) を含む可能性。 ":" まで読み込んだあと "..." なら拾う
+    let foundQuote = false;
+    while (i < n && !/\s/.test(query[i]!)) {
+      if (query[i] === '"') {
+        foundQuote = true;
+        // 接頭辞 + クォート、または単独クォート
+        i++; // skip opening quote
+        while (i < n && query[i] !== '"') i++;
+        if (i < n) i++; // skip closing quote
+        break;
+      }
+      i++;
+    }
+    // foundQuote が無く、かつ末尾がクォートで終わってない通常語の場合
+    // (上のループで i は次の空白かクォート開始位置で止まっている)
+    if (!foundQuote) {
+      // 通常語: 既に i は次の空白の位置
+    }
+    tokens.push({ text: query.slice(start, i) });
+  }
+  return tokens;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                   Parser                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * 1 トークンを TERM / NOT(TERM) ノードへ変換する。
+ *
+ * - 先頭の `-` は否定
+ * - `field:value` 形式で field が既知ならフィールド指定 TERM
+ * - `field:"phrase"` 形式に対応
+ * - 値内のクォートは剥がす
+ */
+function tokenToNode(token: string): SearchNode | null {
+  let text = token;
+  let negate = false;
+  if (text.startsWith("-")) {
+    negate = true;
+    text = text.slice(1);
+  }
+  if (!text) return null;
+
+  let field: SearchField | undefined;
+  // field: 部分を識別
+  const colonIdx = text.indexOf(":");
+  if (colonIdx > 0) {
+    const candidate = text.slice(0, colonIdx).toLowerCase();
+    if (FIELD_NAMES.has(candidate as SearchField)) {
+      field = candidate as SearchField;
+      text = text.slice(colonIdx + 1);
+    }
+  }
+
+  // クォートを剥がす（未閉鎖クォートは閉じたものとして扱う）
+  if (text.startsWith('"')) {
+    text = text.endsWith('"') && text.length >= 2 ? text.slice(1, -1) : text.slice(1);
+  }
+  if (!text) return null;
+
+  const node: SearchNode = field
+    ? { kind: "TERM", field, value: text }
+    : { kind: "TERM", value: text };
+  return negate ? { kind: "NOT", child: node } : node;
+}
+
+/**
+ * クエリ文字列を AST に変換する。
+ *
+ * 文法 (擬似 EBNF):
+ *   query   = or-expr
+ *   or-expr = and-expr ("OR" and-expr)*
+ *   and-expr = term+
+ *   term    = ["-"] [field ":"] (word | phrase)
+ *
+ * OR は AND より優先度が低い。
+ *
+ * 空クエリ・全部 OR/`-` のみは null を返す。
+ */
+export function parseSearchQuery(query: string): SearchNode | null {
+  const tokens = tokenize(query.trim());
+  if (tokens.length === 0) return null;
+
+  const orGroups: SearchNode[][] = [[]];
+  for (const t of tokens) {
+    if (t.text.toUpperCase() === "OR") {
+      // 区切り。次の AND グループを開始
+      if (orGroups[orGroups.length - 1]!.length > 0) {
+        orGroups.push([]);
+      }
+      continue;
+    }
+    const node = tokenToNode(t.text);
+    if (node) orGroups[orGroups.length - 1]!.push(node);
+  }
+
+  // 末尾が空グループだった場合 (例: "foo OR ") は除去
+  const groups = orGroups.filter((g) => g.length > 0);
+  if (groups.length === 0) return null;
+
+  const andOf = (nodes: SearchNode[]): SearchNode =>
+    nodes.length === 1 ? nodes[0]! : { kind: "AND", children: nodes };
+
+  if (groups.length === 1) return andOf(groups[0]!);
+  return { kind: "OR", children: groups.map(andOf) };
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                  Evaluator                                 */
+/* -------------------------------------------------------------------------- */
+
+const HTML_TAG_RE = /<[^>]*>/g;
+
+function stripHtml(html: string): string {
+  return html.replace(HTML_TAG_RE, " ");
+}
+
+function fieldHaystack(article: SearchableArticle, field: SearchField, ctx: SearchContext): string {
+  switch (field) {
+    case "title":
+      return article.title.toLowerCase();
+    case "author":
+      return (article.author ?? "").toLowerCase();
+    case "category":
+      return (article.categories ?? []).join(" ").toLowerCase();
+    case "feed":
+      return (ctx.feedTitleByHash.get(article.feedHash) ?? "").toLowerCase();
+    case "content":
+      return stripHtml(article.content ?? "").toLowerCase();
+  }
+}
+
+function defaultHaystack(article: SearchableArticle, ctx: SearchContext): string {
+  // 既存 articleMatchesQuery 互換 + content も対象に
+  const parts = [
+    article.title,
+    article.summary,
+    article.author ?? "",
+    (article.categories ?? []).join(" "),
+    stripHtml(article.content ?? ""),
+    ctx.feedTitleByHash.get(article.feedHash) ?? "",
+  ];
+  return parts.join(" \u0001 ").toLowerCase();
+}
+
+function evaluate(node: SearchNode, article: SearchableArticle, ctx: SearchContext): boolean {
+  switch (node.kind) {
+    case "TERM": {
+      const needle = node.value.toLowerCase();
+      if (!needle) return true;
+      const haystack = node.field
+        ? fieldHaystack(article, node.field, ctx)
+        : defaultHaystack(article, ctx);
+      return haystack.includes(needle);
+    }
+    case "NOT":
+      return !evaluate(node.child, article, ctx);
+    case "AND":
+      return node.children.every((c) => evaluate(c, article, ctx));
+    case "OR":
+      return node.children.some((c) => evaluate(c, article, ctx));
+  }
+}
+
+/**
+ * 高度クエリで記事をマッチング判定する。
+ *
+ * 空クエリは true。パース失敗 (構文がほぼ無効) も true にフォールバックして UI を空状態にしない。
+ */
+export function matchesAdvancedQuery(
+  article: SearchableArticle,
+  query: string,
+  ctx: SearchContext,
+): boolean {
+  const ast = parseSearchQuery(query);
+  if (!ast) return true;
+  return evaluate(ast, article, ctx);
+}

--- a/src/lib/release-notes-data.ts
+++ b/src/lib/release-notes-data.ts
@@ -8,6 +8,7 @@ export const RELEASE_NOTES_MARKDOWN = `# リリースノート
 
 ### 新機能
 
+- **全フィード横断のフルテキスト検索と高度フィルタリング** — Issue #102。検索ボックスに高度クエリ構文を追加：フィールド指定 (\`title:foo\` / \`author:bar\` / \`feed:baz\` / \`category:qux\` / \`content:hello\`)、フレーズ検索 (\`"hello world"\`)、否定 (\`-foo\`)、暗黙 AND・明示 OR (\`foo OR bar\`)、大文字小文字無視。構文を含まない単純クエリは従来通り title / summary / author / categories / content を横断する既存互換挙動。\`src/lib/full-text-search.ts\` に純粋関数 (\`parseSearchQuery\` / \`matchesAdvancedQuery\`) として実装し、\`src/lib/article-filter.ts\` の \`buildQueryPredicate\` から呼び出す。\`SearchContext.feedTitleByHash\` を \`useFilteredArticles\` 側で構築し \`feed:\` クエリを解決可能に。検索条件の保存機能 (\`useFullTextSearch\` フック) を新設、\`localStorage\` (\`rss-saved-searches\`) に最大 20 件まで保存し検索ドロップダウンの「保存済み」セクションから即時呼び出せる。検索バー右側に「保存」ボタンを追加 (2 文字以上の入力時のみ表示)。\`e2e/full-text-search.spec.ts\` に 42 ケース追加 (parseSearchQuery / matchesAdvancedQuery のフィールド・OR/AND/NOT・フレーズ・エッジケース・未閉鎖クォート fallback・OR の大小無視)。
 - **フィードビュータブ + Pinterest 風ギャラリーレイアウト** — Issue #114。サイドバー上部に「記事 / 画像 / 動画 / SNS」の 4 タブを追加し、各フィードを任意のカテゴリに分類できるようにした。タブ切替で対応する view のフィードのみが表示される（未分類フィードは「記事」タブ所属扱い）。併せて \`gallery\` レイアウトを新設（CSS columns による masonry、サムネイル優先）。\`UserSubscription.view\` / \`Feed.view\` / \`FeedPatchPayload.view\` を追加し、\`PATCH /api/feeds/:id\` で \`view: "articles" | "pictures" | "videos" | "social" | null\` を受け付ける。\`FeedItem\` のコンテキストメニューに「表示カテゴリ」サブメニューを追加。localStorage キー \`rss-active-feed-view\` にタブ選択状態を永続化。UX は [Folo](https://github.com/RSSNext/Folo)（AGPL-3.0）を参考にしたがコードは流用せず MIT のままとした。
 
 ### バグ修正

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -60,6 +60,7 @@ export const STORAGE_KEYS = {
   AUTO_READ_ENABLED: "rss-auto-read-enabled",
   AUTO_READ_THRESHOLD: "rss-auto-read-threshold",
   ACTIVE_FEED_VIEW: "rss-active-feed-view",
+  SAVED_SEARCHES: "rss-saved-searches",
 } as const;
 
 // ── 低レベルラッパー ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Issue #102 の対応。検索ボックスに高度クエリ構文と保存検索機能を追加。

- フィールド指定 (`title:foo` / `author:bar` / `feed:baz` / `category:qux` / `content:hello`)、フレーズ検索 (`"hello world"`)、否定 (`-foo`)、暗黙 AND・明示 OR (`foo OR bar`)、大文字小文字無視
- 構文を含まない単純クエリは title / summary / author / categories / content を横断する既存互換挙動
- 検索条件を localStorage (`rss-saved-searches`) に最大 20 件まで名前付きで保存。検索ドロップダウンの「保存済み」セクションから即時呼び出せる
- `src/lib/full-text-search.ts` に純粋関数 (`parseSearchQuery` / `matchesAdvancedQuery`) として実装し、`src/lib/article-filter.ts` の `buildQueryPredicate` から呼び出す
- `e2e/full-text-search.spec.ts` に 42 ケース追加

## Test plan

- [x] `npm run check` (oxlint + oxfmt)
- [x] `npm run typecheck` (tsc)
- [x] `npm run build` (next build)
- [x] `npx playwright test e2e/full-text-search.spec.ts e2e/article-filter.spec.ts e2e/article-search.spec.ts` (125/125 pass)
- [x] code-reviewer agent によるレビュー実施・指摘修正済み (未閉鎖クォート fallback / OR 大小無視 / ReadonlyMap 統一 / prompt の trim)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Advanced full-text search with field-scoped filters, phrase search, negation, AND/OR operators, and case-insensitive matching.
  * Save search queries for quick access (up to 20 saved searches).
  * Feed view tabs (articles, images, videos, social) with gallery layout for visual content.
  * Display category option in feed menus.

* **Tests**
  * Added 42 new end-to-end test cases for search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->