### PR TITLE
新機能: ショートカット一覧ボタン + 記事一覧フォーカストグル (#148)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # リリースノート
 
+## 2026-04-21
+
+### 新機能
+
+- **キーボードショートカット一覧ボタン + 記事一覧フォーカスモード切替ボタンを追加** — Issue #148。`?` キーでしか開けなかった `KeyboardShortcutsModal` の UI 導線と、`Shift+\`（= `|`）以外に有効化手段がなかった `listFocusMode`（記事一覧フォーカス）の UI 導線を同時に整備。`FeedSidebar` のフッター（ユーザー設定・テーマ切替ボタンの隣）に `onOpenHelp` で開くヘルプ系 `FooterIconButton`（`?` 付き丸アイコン）を追加し、`App.tsx` から `setShowHelp(true)` を配線。`ArticleList` ツールバーのレイアウト切替ボタン群の直後に `listFocusMode` トグルボタン（`ArticleView` の `focusMode` トグルと対称な 4 隅矢印アイコン、`aria-pressed` 付き）を配置し、`onToggleListFocusMode` prop 経由で `useUIState` の `toggleListFocusMode` を呼ぶ。`LAYOUTS.map` と同じ w-6/h-6 サイズで統一し、既存のピルボタン群と視覚的に馴染ませた。これで `|` / `\` キーバインドを知らないユーザーもヘルプから全ショートカットを参照でき、`listFocusMode` を明示的に ON / OFF できる。
+
 ## 2026-04-20
 
 ### 新機能

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ export default function App() {
     focusMode,
     toggleFocusMode,
     listFocusMode,
+    toggleListFocusMode,
     setListFocusMode,
     exitFocusMode,
     nsfwMode,
@@ -1058,6 +1059,7 @@ export default function App() {
                 onMarkAllRead={markAllRead}
                 onToggleTheme={toggleTheme}
                 onOpenSettings={() => setShowSettings(true)}
+                onOpenHelp={() => setShowHelp(true)}
                 onSaveArticleUrl={onSaveArticleUrl}
                 onRefresh={refreshFeeds}
                 onRetryFeed={retryFeed}
@@ -1166,6 +1168,8 @@ export default function App() {
                 onLoadMoreFeedArticles={handleLoadMoreFeedArticles}
                 notes={notes}
                 activeFeedView={activeFeedView}
+                listFocusMode={listFocusMode}
+                onToggleListFocusMode={toggleListFocusMode}
               />
             </ErrorBoundary>
           </div>

--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -64,6 +64,9 @@ interface Props {
    * 先行取得して本文内の全画像をカードに展開する（usePrefetchGalleryContents）。
    */
   activeFeedView?: FeedView;
+  /** 記事一覧フォーカスモード（サイドバーと記事ビューを畳む） */
+  listFocusMode: boolean;
+  onToggleListFocusMode: () => void;
 }
 
 const LAYOUT_ICONS: Record<Layout, ReactElement> = {
@@ -218,6 +221,8 @@ export default function ArticleList({
   onLoadMoreFeedArticles,
   notes,
   activeFeedView,
+  listFocusMode,
+  onToggleListFocusMode,
 }: Props) {
   const {
     filtered,
@@ -512,6 +517,46 @@ export default function ArticleList({
                 </button>
               ))}
             </div>
+            {/* 記事一覧フォーカスモード切替 */}
+            <button
+              onClick={onToggleListFocusMode}
+              className={`w-6 h-6 flex items-center justify-center rounded-full transition-all duration-200 ${
+                listFocusMode
+                  ? "text-text-strong bg-surface-subtle"
+                  : "text-text-faint hover:text-text-muted hover:bg-surface-subtle"
+              }`}
+              title={listFocusMode ? "記事一覧フォーカス終了 (|)" : "記事一覧フォーカス (|)"}
+              aria-label={listFocusMode ? "記事一覧フォーカス終了" : "記事一覧フォーカス"}
+              aria-pressed={listFocusMode}
+            >
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                {listFocusMode ? (
+                  <>
+                    <path d="M9 9L3 3m0 0h6m-6 0v6" />
+                    <path d="M15 9l6-6m0 0h-6m6 0v6" />
+                    <path d="M9 15l-6 6m0 0h6m-6 0v-6" />
+                    <path d="M15 15l6 6m0 0h-6m6 0v-6" />
+                  </>
+                ) : (
+                  <>
+                    <path d="M3 9V3m0 0h6M3 3l6 6" />
+                    <path d="M21 9V3m0 0h-6m6 0l-6 6" />
+                    <path d="M3 15v6m0 0h6m-6 0l6-6" />
+                    <path d="M21 15v6m0 0h-6m6 0l-6-6" />
+                  </>
+                )}
+              </svg>
+            </button>
             <FilterPillButton
               active={unreadOnly}
               onClick={toggleUnreadOnly}

--- a/src/components/FeedSidebar.tsx
+++ b/src/components/FeedSidebar.tsx
@@ -42,6 +42,7 @@ interface Props {
   onMarkAllRead: (feedId: string | null) => void;
   onToggleTheme: () => void;
   onOpenSettings: () => void;
+  onOpenHelp: () => void;
   onSaveArticleUrl: (url: string, mode: "bookmark" | "reading_list") => Promise<void>;
   onRefresh: () => void;
   onRetryFeed: (id: string) => Promise<void>;
@@ -712,6 +713,7 @@ export default function FeedSidebar({
   onMarkAllRead,
   onToggleTheme,
   onOpenSettings,
+  onOpenHelp,
   onSaveArticleUrl,
   onRefresh,
   onRetryFeed,
@@ -1586,6 +1588,13 @@ export default function FeedSidebar({
             d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
           />
           <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        </FooterIconButton>
+        <FooterIconButton onClick={onOpenHelp} title="キーボードショートカット (?)">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.5M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z"
+          />
         </FooterIconButton>
         <FooterIconButton
           onClick={onToggleTheme}

--- a/src/lib/release-notes-data.ts
+++ b/src/lib/release-notes-data.ts
@@ -4,6 +4,12 @@
  */
 export const RELEASE_NOTES_MARKDOWN = `# リリースノート
 
+## 2026-04-21
+
+### 新機能
+
+- **キーボードショートカット一覧ボタン + 記事一覧フォーカスモード切替ボタンを追加** — Issue #148。\`?\` キーでしか開けなかった \`KeyboardShortcutsModal\` の UI 導線と、\`Shift+\\\`（= \`|\`）以外に有効化手段がなかった \`listFocusMode\`（記事一覧フォーカス）の UI 導線を同時に整備。\`FeedSidebar\` のフッター（ユーザー設定・テーマ切替ボタンの隣）に \`onOpenHelp\` で開くヘルプ系 \`FooterIconButton\`（\`?\` 付き丸アイコン）を追加し、\`App.tsx\` から \`setShowHelp(true)\` を配線。\`ArticleList\` ツールバーのレイアウト切替ボタン群の直後に \`listFocusMode\` トグルボタン（\`ArticleView\` の \`focusMode\` トグルと対称な 4 隅矢印アイコン、\`aria-pressed\` 付き）を配置し、\`onToggleListFocusMode\` prop 経由で \`useUIState\` の \`toggleListFocusMode\` を呼ぶ。\`LAYOUTS.map\` と同じ w-6/h-6 サイズで統一し、既存のピルボタン群と視覚的に馴染ませた。これで \`|\` / \`\\\` キーバインドを知らないユーザーもヘルプから全ショートカットを参照でき、\`listFocusMode\` を明示的に ON / OFF できる。
+
 ## 2026-04-20
 
 ### 新機能


### PR DESCRIPTION
## Summary

#143 対応中に発覚した UX ギャップを2点まとめて対応。

- **FeedSidebar フッターに「?」ヘルプボタン追加** — 従来 `?` キーでしか開けなかった `KeyboardShortcutsModal` を UI から開けるようにした
- **ArticleList ツールバーに listFocusMode トグルボタン追加** — `ArticleView` の `focusMode` トグルと対称な位置・アイコン。`Shift+\`（= `|`）を知らなくても明示的に記事一覧フォーカスを ON/OFF できる

## Test plan

- [x] `npm run check`（oxlint + oxfmt）通過
- [x] `npm run typecheck`（tsc --noEmit）通過
- [x] Playwright E2E 1119 テスト全通過
- [ ] ブラウザで FeedSidebar フッターの「?」ボタン押下 → ショートカット一覧が開くこと
- [ ] ArticleList の 4 隅矢印ボタン押下 → 記事一覧フォーカスが切替わり、`aria-pressed` が同期されること

Closes #148