### PR TITLE
fix: cascadeOverflow が MAX_PAGES 超過時に oversizeAlert フラグを記録 (fixes #183)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ## 2026-04-22
 
+### バグ修正っ
+
+- `cascadeOverflow()` が MAX_PAGES を超過したとき `SharedFeedMeta.oversizeAlert` フラグを立てるようにしたよ〜。`console.warn` だけじゃ気づけなかった問題を修正！💡
+
 ### リファクタリングっ
 
 - **`LayoutIcon` コンポーネントを分離** — Issue #184。`ArticleList.tsx` にインライン定義されてた 5 種類のレイアウトアイコン SVG を `src/components/LayoutIcon.tsx` として切り出したよ〜！40 行超の visual noise がスッキリして、再利用もできるようになったの🧹✨

--- a/e2e/cascade-overflow.spec.ts
+++ b/e2e/cascade-overflow.spec.ts
@@ -48,12 +48,13 @@ test("cascadeOverflow: 既存の空きに収まる場合は1ページ書き込�
     makeArticle("a2", "2026-01-02T00:00:00Z"),
   ];
 
-  const lastPage = await cascadeOverflow(bucket, "feed1", overflow, 2, {
+  const result = await cascadeOverflow(bucket, "feed1", overflow, 2, {
     maxPages: 5,
     pageSize: 3,
   });
 
-  expect(lastPage).toBe(2);
+  expect(result.lastWrittenPage).toBe(2);
+  expect(result.oversized).toBe(false);
   expect(store.size).toBe(1);
   const p2 = JSON.parse(store.get("feeds/feed1/articles/p2.json")!) as Article[];
   expect(p2).toHaveLength(2);
@@ -77,12 +78,13 @@ test("cascadeOverflow: ページ溢れ時に次ページへカスケードする
     makeArticle("new3", "2026-01-01T00:00:00Z"),
   ];
 
-  const lastPage = await cascadeOverflow(bucket, "feed1", overflow, 2, {
+  const result = await cascadeOverflow(bucket, "feed1", overflow, 2, {
     maxPages: 5,
     pageSize: 3,
   });
 
-  expect(lastPage).toBe(3);
+  expect(result.lastWrittenPage).toBe(3);
+  expect(result.oversized).toBe(false);
   const p2 = JSON.parse(store.get("feeds/feed1/articles/p2.json")!) as Article[];
   const p3 = JSON.parse(store.get("feeds/feed1/articles/p3.json")!) as Article[];
   expect(p2).toHaveLength(3);
@@ -125,12 +127,13 @@ test("Issue #131: maxPages 超過時に overflow を silent drop せず末尾ペ
   console.warn = (msg: string) => warnings.push(msg);
 
   try {
-    const lastPage = await cascadeOverflow(bucket, "feed1", overflow, 2, {
+    const result = await cascadeOverflow(bucket, "feed1", overflow, 2, {
       maxPages,
       pageSize,
     });
 
-    expect(lastPage).toBe(maxPages);
+    expect(result.lastWrittenPage).toBe(maxPages);
+    expect(result.oversized).toBe(true);
     // 全記事の合計: overflow 3件 + p2(2件) + p3(2件) = 7件
     const allStored = [...store.values()]
       .flatMap((v) => JSON.parse(v) as Article[])
@@ -198,12 +201,13 @@ test("Issue #158: overflow と既存ページで重複する記事が排除さ�
     makeArticle("dup1", "2026-01-01T00:00:00Z"),
   ];
 
-  const lastPage = await cascadeOverflow(bucket, "feed1", overflow, 2, {
+  const result = await cascadeOverflow(bucket, "feed1", overflow, 2, {
     maxPages: 5,
     pageSize: 5,
   });
 
-  expect(lastPage).toBe(2);
+  expect(result.lastWrittenPage).toBe(2);
+  expect(result.oversized).toBe(false);
   const p2 = JSON.parse(store.get("feeds/feed1/articles/p2.json")!) as Article[];
   // dup1 は重複排除されて 1件のみ（overflow 側が優先）
   expect(p2).toHaveLength(3);

--- a/src/lib/release-notes-data.ts
+++ b/src/lib/release-notes-data.ts
@@ -3,6 +3,10 @@ export const RELEASE_NOTES_MARKDOWN = `
 
 ## 2026-04-22
 
+### バグ修正っ
+
+- \`cascadeOverflow()\` が MAX_PAGES を超過したとき \`SharedFeedMeta.oversizeAlert\` フラグを立てるようにしたよ〜。\`console.warn\` だけじゃ気づけなかった問題を修正！💡
+
 ### リファクタリングっ
 
 - **\`LayoutIcon\` コンポーネントを分離** — Issue #184。\`ArticleList.tsx\` にインライン定義されてた 5 種類のレイアウトアイコン SVG を \`src/components/LayoutIcon.tsx\` として切り出したよ〜！40 行超の visual noise がスッキリして、再利用もできるようになったの🧹✨

--- a/src/lib/shared-feed.ts
+++ b/src/lib/shared-feed.ts
@@ -158,7 +158,7 @@ export async function cascadeOverflow(
   overflow: Article[],
   pageNum: number,
   options?: { maxPages?: number; pageSize?: number },
-): Promise<number> {
+): Promise<{ lastWrittenPage: number; oversized: boolean }> {
   const maxPages = options?.maxPages ?? MAX_PAGES;
   const pageSize = options?.pageSize ?? PAGE_SIZE;
 
@@ -199,9 +199,10 @@ export async function cascadeOverflow(
         `Appended ${currentOverflow.length} articles to p${maxPages} ` +
         `(page now holds ${merged.length} items, exceeds PAGE_SIZE=${pageSize}).`,
     );
+    return { lastWrittenPage, oversized: true };
   }
 
-  return lastWrittenPage;
+  return { lastWrittenPage, oversized: false };
 }
 
 /**
@@ -276,8 +277,14 @@ export async function mergeNewArticles(
     const newLatest = merged.slice(0, PAGE_SIZE);
     const overflow = merged.slice(PAGE_SIZE);
     await r2Put(bucket, latestKey(meta.feedHash), newLatest);
-    const maxPage = await cascadeOverflow(bucket, meta.feedHash, overflow, 2);
+    const { lastWrittenPage: maxPage, oversized } = await cascadeOverflow(
+      bucket,
+      meta.feedHash,
+      overflow,
+      2,
+    );
     meta.pageCount = Math.max(meta.pageCount, maxPage - 1); // pageCount は p2以降の数
+    if (oversized) meta.oversizeAlert = true;
   }
 
   // knownIds を更新

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,8 @@ export interface SharedFeedMeta {
   cssSelectors?: SelectorConfig;
   /** 過去に試して失敗した articleLink セレクタの履歴（再推論時の除外用） */
   failedSelectors?: string[];
+  /** MAX_PAGES を超えた overflow を末尾ページに追記した際に true になる監視フラグ */
+  oversizeAlert?: boolean;
 }
 
 /** フィードごとのキーワードフィルター */


### PR DESCRIPTION
## Summary

- `SharedFeedMeta` に `oversizeAlert?: boolean` フィールドを追加
- `cascadeOverflow()` の戻り値を `Promise<number>` → `Promise<{ lastWrittenPage: number; oversized: boolean }>` に変更
- MAX_PAGES 超過検知時に `meta.oversizeAlert = true` を記録するよう `mergeNewArticles` を更新
- E2E テストも戻り値変更に追従して更新

## Test plan

- [ ] `npm run check` (Oxlint + Oxfmt) 通過
- [ ] `npm run typecheck` (tsc) 通過
- [ ] E2E テスト通過（cascade-overflow.spec.ts の `oversized` フラグ検証含む）

Closes #183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feed now properly tracks and alerts when article content exceeds the maximum page capacity, improving visibility into overflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->