### PR TITLE
fix: RSS コンテンツの相対パス画像 (avif 等) が 404 になる問題を修正 (#215)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ## 2026-04-24
 
+### バグ修正っ
+
+- **RSS コンテンツの相対パス画像（avif 等）が 404 になる問題を修正** — Issue #215。フィードの `content:encoded` に含まれる相対パス `<img src="/images/photo.avif">` が rss.0g0.xyz のパスとして解釈されて 404 になってたのを直したよ〜！`xml-parser.ts` の RSS 2.0 / Atom / RDF / JSON Feed すべてのパーサーで `sanitizeHtml` のかわりに `applyCorePipeline(raw, link)` を呼ぶようにして、記事の URL を baseUrl として相対パスを絶対 URL に解決してからプロキシ経由に書き換えるようになったっ。`image-mime.ts` も Sequence AVIF (`avis` brand) を `image/avif` として認識できるように修正したよっ！💡🖼️
+
 ### セキュリティ対策っ
 
 - **DBSC sessionId に UUID 形式検証を追加** — Issue #196。`challenge` と `register` の両エンドポイントで、クライアント送信の `sessionId` に `../` や `%2f` を含む値を渡しても R2 キーが不正なパスにならないよう UUID フォーマット検証を追加したよ〜！`/^[0-9a-f]{8}-...-[0-9a-f]{12}$/i` にマッチしない場合は 400 を返すようになったっ🔒

--- a/src/lib/html-post-processor.ts
+++ b/src/lib/html-post-processor.ts
@@ -618,7 +618,7 @@ export function transformXTweetEmbeds(html: string, theme: "light" | "dark" = "l
  *   4. wrapTables:         <table> をレスポンシブラッパーで包む
  *   5. sanitizeHtml:       XSS 除去（必ず最後。これ以降に処理を追加しても無効化される）
  */
-function applyCorePipeline(html: string, pageUrl = ""): string {
+export function applyCorePipeline(html: string, pageUrl = ""): string {
   let h = fixImageDimensions(html, pageUrl);
   h = rewriteImageUrls(h);
   h = fixExternalLinks(h, pageUrl);

--- a/src/lib/image-mime.ts
+++ b/src/lib/image-mime.ts
@@ -69,7 +69,7 @@ export function detectImageMimeType(bytes: Uint8Array): string | null {
     bytes[7] === 0x70
   ) {
     const brand = String.fromCharCode(bytes[8], bytes[9], bytes[10], bytes[11]);
-    if (brand === "avif") return "image/avif";
+    if (brand === "avif" || brand === "avis") return "image/avif"; // avis = Sequence AVIF
     if (brand === "heic" || brand === "heix") return null; // HEIC はブラウザ未対応のため拒否
   }
 

--- a/src/lib/release-notes-data.ts
+++ b/src/lib/release-notes-data.ts
@@ -3,6 +3,10 @@ export const RELEASE_NOTES_MARKDOWN = `
 
 ## 2026-04-24
 
+### バグ修正っ
+
+- **RSS コンテンツの相対パス画像（avif 等）が 404 になる問題を修正** — Issue #215。フィードの \`content:encoded\` に含まれる相対パス \`<img src="/images/photo.avif">\` が rss.0g0.xyz のパスとして解釈されて 404 になってたのを直したよ〜！\`xml-parser.ts\` の RSS 2.0 / Atom / RDF / JSON Feed すべてのパーサーで \`sanitizeHtml\` のかわりに \`applyCorePipeline(raw, link)\` を呼ぶようにして、記事の URL を baseUrl として相対パスを絶対 URL に解決してからプロキシ経由に書き換えるようになったっ。\`image-mime.ts\` も Sequence AVIF (\`avis\` brand) を \`image/avif\` として認識できるように修正したよっ！💡🖼️
+
 ### セキュリティ対策っ
 
 - **DBSC sessionId に UUID 形式検証を追加** — Issue #196。\`challenge\` と \`register\` の両エンドポイントで、クライアント送信の \`sessionId\` に \`../\` や \`%2f\` を含む値を渡しても R2 キーが不正なパスにならないよう UUID フォーマット検証を追加したよ〜！\`/^[0-9a-f]{8}-...-[0-9a-f]{12}$/i\` にマッチしない場合は 400 を返すようになったっ🔒

--- a/src/lib/xml-parser.ts
+++ b/src/lib/xml-parser.ts
@@ -1,5 +1,6 @@
 import { XMLParser } from "fast-xml-parser";
-import { sanitizeHtml, unescapeHtml, stripHtml } from "./html";
+import { unescapeHtml, stripHtml } from "./html";
+import { applyCorePipeline } from "./html-post-processor";
 
 /** XML 属性を持つノード（fast-xml-parser の属性プレフィックス "@_" 付き） */
 interface XmlAttr {
@@ -360,7 +361,8 @@ function parseJsonFeed(data: JsonFeedRoot): ParsedFeed {
   const items: ParsedItem[] = (data.items ?? []).map((item) => {
     const raw = item.content_html ?? item.content_text ?? item.summary ?? "";
     const isHtml = !!item.content_html;
-    const content = isHtml ? sanitizeHtml(raw) : raw;
+    const link = safeUrl(item.url ?? item.external_url ?? "");
+    const content = isHtml ? applyCorePipeline(raw, link) : raw;
     const summary = item.summary
       ? stripHtml(item.summary).slice(0, 200)
       : (isHtml ? stripHtml(raw) : raw).slice(0, 200);
@@ -372,7 +374,7 @@ function parseJsonFeed(data: JsonFeedRoot): ParsedFeed {
     return {
       guid: item.id ?? item.url ?? "",
       title: item.title ?? "",
-      link: safeUrl(item.url ?? item.external_url ?? ""),
+      link,
       summary,
       content,
       ogImage: safeUrl(item.image ?? item.banner_image ?? ""),
@@ -426,12 +428,13 @@ export function parseFeed(xml: string): ParsedFeed {
       siteUrl: str(ch.link),
       items: toArray(ch.item).map((item) => {
         const raw = unwrapCdata(str(item["content:encoded"] ?? item.description ?? ""));
+        const link = safeUrl(str(item.link));
         return {
           guid: str(item.guid ?? item.link),
           title: stripHtml(str(item.title)),
-          link: safeUrl(str(item.link)),
+          link,
           summary: stripHtml(raw).slice(0, 200),
-          content: sanitizeHtml(raw),
+          content: applyCorePipeline(raw, link),
           ogImage: safeUrl(extractImage(item)),
           author: stripHtml(str(item["dc:creator"]) || authorStr(item.author)).trim(),
           publishedAt: parseDate(str(item.pubDate) || null),
@@ -455,16 +458,17 @@ export function parseFeed(xml: string): ParsedFeed {
         // Atom の link は isArray 設定により常に XmlAttr[] になる
         const entryLinks = toArray<XmlAttr>(entry.link as XmlAttr | XmlAttr[] | undefined);
         const raw = unwrapCdata(str(entry.content ?? entry.summary ?? ""));
+        const link = safeUrl(
+          entryLinks.find((l) => l["@_rel"] !== "self")?.["@_href"] ??
+            entryLinks[0]?.["@_href"] ??
+            "",
+        );
         return {
           guid: str(entry.id),
           title: stripHtml(str(entry.title)),
-          link: safeUrl(
-            entryLinks.find((l) => l["@_rel"] !== "self")?.["@_href"] ??
-              entryLinks[0]?.["@_href"] ??
-              "",
-          ),
+          link,
           summary: stripHtml(raw).slice(0, 200),
-          content: sanitizeHtml(raw),
+          content: applyCorePipeline(raw, link),
           ogImage: safeUrl(extractImage(entry)),
           author: stripHtml(authorStr(entry.author) || authorStr(feed.author)).trim(),
           publishedAt: parseDate(entry.published ?? entry.updated),
@@ -492,12 +496,13 @@ export function parseFeed(xml: string): ParsedFeed {
         const raw = unwrapCdata(str(item["content:encoded"] ?? item.description ?? ""));
         // RSS 1.0 は guid がなく rdf:about 属性が識別子を兼ねる
         const guid = str(item.guid ?? item["@_rdf:about"] ?? item.link);
+        const link = safeUrl(str(item.link) || str(item["@_rdf:about"]));
         return {
           guid,
           title: stripHtml(str(item.title)),
-          link: safeUrl(str(item.link) || str(item["@_rdf:about"])),
+          link,
           summary: stripHtml(raw).slice(0, 200),
-          content: sanitizeHtml(raw),
+          content: applyCorePipeline(raw, link),
           ogImage: safeUrl(extractImage(item)),
           author: stripHtml(str(item["dc:creator"]) || authorStr(item.author)).trim(),
           // RSS 1.0 は dc:date（ISO 8601）が主要。pubDate は一部サイト独自の拡張として存在しうるためフォールバックに使う


### PR DESCRIPTION
## 問題

RSS フィードの `content:encoded` に含まれる相対パス画像（`/images/photo.avif` 等）が、ブラウザから `rss.0g0.xyz/images/photo.avif` として解釈されて 404 になっていた。

## 原因

`xml-parser.ts` では `sanitizeHtml(raw)` のみを呼び、相対 URL の解決を行っていなかった。

## 修正内容

- **`src/lib/xml-parser.ts`**: RSS 2.0 / Atom / RDF / JSON Feed のすべてのパーサーで `sanitizeHtml(raw)` → `applyCorePipeline(raw, link)` に変更。記事の `link` を baseUrl として相対パス画像 URL を絶対 URL に解決し、`/api/image-proxy` 経由に書き換え
- **`src/lib/html-post-processor.ts`**: `applyCorePipeline` を `export` に変更
- **`src/lib/image-mime.ts`**: Sequence AVIF (`avis` brand) を `image/avif` として認識するよう追加

## テスト

- `npm run check` — pass（警告・エラーなし）
- `npm run typecheck` — pass
- playwright 1140 tests — 1140 passed

Closes #215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed RSS feed images with relative paths returning 404 errors. Relative image URLs in feed content are now correctly resolved using the article URL before proxy rewriting.

* **Improvements**
  * Extended AVIF image format detection to recognize Sequence AVIF variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->