### PR TITLE
simplify: articleMatchesQuery を廃止して matchesAdvancedQuery に統合 (#210)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,10 @@
 
 - **RSS コンテンツの相対パス画像（avif 等）が 404 になる問題を修正** — Issue #215。フィードの `content:encoded` に含まれる相対パス `<img src="/images/photo.avif">` が rss.0g0.xyz のパスとして解釈されて 404 になってたのを直したよ〜！`xml-parser.ts` の RSS 2.0 / Atom / RDF / JSON Feed すべてのパーサーで `sanitizeHtml` のかわりに `applyCorePipeline(raw, link)` を呼ぶようにして、記事の URL を baseUrl として相対パスを絶対 URL に解決してからプロキシ経由に書き換えるようになったっ。`image-mime.ts` も Sequence AVIF (`avis` brand) を `image/avif` として認識できるように修正したよっ！💡🖼️
 
+### リファクタリングっ
+
+- **`articleMatchesQuery` を廃止して `matchesAdvancedQuery` に統合** — Issue #210。`src/lib/article-utils.ts` の `articleMatchesQuery`（スペース区切り AND 検索のみ対応）は本番コードで既に使われておらず、`src/lib/article-filter.ts` が `matchesAdvancedQuery`（フィールド指定・OR・否定・フレーズ検索まで対応）に移行済みだったからデッドコードを削除したよ〜！テストも `matchesAdvancedQuery` を直接テストするよう書き直して、将来的な乖離リスクをゼロにしたっ✨🧹
+
 ### セキュリティ対策っ
 
 - **DBSC sessionId に UUID 形式検証を追加** — Issue #196。`challenge` と `register` の両エンドポイントで、クライアント送信の `sessionId` に `../` や `%2f` を含む値を渡しても R2 キーが不正なパスにならないよう UUID フォーマット検証を追加したよ〜！`/^[0-9a-f]{8}-...-[0-9a-f]{12}$/i` にマッチしない場合は 400 を返すようになったっ🔒

--- a/e2e/article-search.spec.ts
+++ b/e2e/article-search.spec.ts
@@ -1,119 +1,130 @@
 import { test, expect } from "@playwright/test";
-import { articleMatchesQuery } from "../src/lib/article-utils";
+import { matchesAdvancedQuery, type SearchContext } from "../src/lib/full-text-search";
 
 /**
- * articleMatchesQuery の単体テスト。
+ * matchesAdvancedQuery の単体テスト。
  *
  * 全文検索が title・summary・author・categories を AND 検索することを検証する。
+ * （旧 articleMatchesQuery の機能は matchesAdvancedQuery に統合済み）
  */
 
+const EMPTY_CTX: SearchContext = { feedTitleByHash: new Map() };
+
 const BASE = {
+  feedHash: "",
   title: "TypeScript で始める関数型プログラミング",
   summary: "モナドとファンクターの使い方を解説します。",
   author: "山田 太郎",
   categories: ["TypeScript", "関数型", "プログラミング"],
 };
 
-test.describe("articleMatchesQuery — 基本動作", () => {
+const match = (
+  article:
+    | typeof BASE
+    | { feedHash: string; title: string; summary: string; author?: string; categories?: string[] },
+  query: string,
+) => matchesAdvancedQuery(article, query, EMPTY_CTX);
+
+test.describe("matchesAdvancedQuery — 基本動作", () => {
   test("空クエリは常に true を返す", () => {
-    expect(articleMatchesQuery(BASE, "")).toBe(true);
-    expect(articleMatchesQuery(BASE, "   ")).toBe(true);
+    expect(match(BASE, "")).toBe(true);
+    expect(match(BASE, "   ")).toBe(true);
   });
 
   test("タイトルにマッチする", () => {
-    expect(articleMatchesQuery(BASE, "TypeScript")).toBe(true);
+    expect(match(BASE, "TypeScript")).toBe(true);
   });
 
   test("サマリーにマッチする", () => {
-    expect(articleMatchesQuery(BASE, "モナド")).toBe(true);
+    expect(match(BASE, "モナド")).toBe(true);
   });
 
   test("マッチしないクエリは false を返す", () => {
-    expect(articleMatchesQuery(BASE, "Rust")).toBe(false);
+    expect(match(BASE, "Rust")).toBe(false);
   });
 });
 
-test.describe("articleMatchesQuery — author 検索", () => {
+test.describe("matchesAdvancedQuery — author 検索", () => {
   test("author 名でマッチする", () => {
-    expect(articleMatchesQuery(BASE, "山田")).toBe(true);
+    expect(match(BASE, "山田")).toBe(true);
   });
 
   test("author フルネームでマッチする", () => {
-    expect(articleMatchesQuery(BASE, "山田 太郎")).toBe(true);
+    expect(match(BASE, "山田 太郎")).toBe(true);
   });
 
   test("author が undefined のときエラーにならない", () => {
-    const a = { title: "foo", summary: "bar" };
-    expect(articleMatchesQuery(a, "山田")).toBe(false);
+    const a = { feedHash: "", title: "foo", summary: "bar" };
+    expect(match(a, "山田")).toBe(false);
   });
 
   test("author が空文字のときエラーにならない", () => {
-    const a = { title: "foo", summary: "bar", author: "" };
-    expect(articleMatchesQuery(a, "山田")).toBe(false);
+    const a = { feedHash: "", title: "foo", summary: "bar", author: "" };
+    expect(match(a, "山田")).toBe(false);
   });
 });
 
-test.describe("articleMatchesQuery — categories 検索", () => {
+test.describe("matchesAdvancedQuery — categories 検索", () => {
   test("categories の単語でマッチする", () => {
-    expect(articleMatchesQuery(BASE, "関数型")).toBe(true);
+    expect(match(BASE, "関数型")).toBe(true);
   });
 
   test("categories に含まれる英語タグでマッチする", () => {
-    expect(articleMatchesQuery(BASE, "typescript")).toBe(true); // 大文字小文字無視
+    expect(match(BASE, "typescript")).toBe(true); // 大文字小文字無視
   });
 
   test("categories が undefined のときエラーにならない", () => {
-    const a = { title: "foo", summary: "bar" };
-    expect(articleMatchesQuery(a, "関数型")).toBe(false);
+    const a = { feedHash: "", title: "foo", summary: "bar" };
+    expect(match(a, "関数型")).toBe(false);
   });
 
   test("categories が空配列のときエラーにならない", () => {
-    const a = { title: "foo", summary: "bar", categories: [] };
-    expect(articleMatchesQuery(a, "TypeScript")).toBe(false);
+    const a = { feedHash: "", title: "foo", summary: "bar", categories: [] };
+    expect(match(a, "TypeScript")).toBe(false);
   });
 });
 
-test.describe("articleMatchesQuery — AND 検索（複数ワード）", () => {
+test.describe("matchesAdvancedQuery — AND 検索（複数ワード）", () => {
   test("全ワードにマッチすれば true", () => {
     // title に TypeScript、summary にモナド
-    expect(articleMatchesQuery(BASE, "TypeScript モナド")).toBe(true);
+    expect(match(BASE, "TypeScript モナド")).toBe(true);
   });
 
   test("1 ワードでもミスマッチがあれば false", () => {
-    expect(articleMatchesQuery(BASE, "TypeScript Rust")).toBe(false);
+    expect(match(BASE, "TypeScript Rust")).toBe(false);
   });
 
   test("author + title のクロスフィールド AND", () => {
     // TypeScript は title に、山田 は author に存在
-    expect(articleMatchesQuery(BASE, "TypeScript 山田")).toBe(true);
+    expect(match(BASE, "TypeScript 山田")).toBe(true);
   });
 
   test("categories + author のクロスフィールド AND", () => {
-    expect(articleMatchesQuery(BASE, "関数型 太郎")).toBe(true);
+    expect(match(BASE, "関数型 太郎")).toBe(true);
   });
 
   test("3 フィールドにまたがる AND", () => {
     // title=TypeScript、summary=モナド、author=山田
-    expect(articleMatchesQuery(BASE, "TypeScript モナド 山田")).toBe(true);
+    expect(match(BASE, "TypeScript モナド 山田")).toBe(true);
   });
 });
 
-test.describe("articleMatchesQuery — 大文字小文字を無視", () => {
+test.describe("matchesAdvancedQuery — 大文字小文字を無視", () => {
   test("大文字クエリでタイトルにマッチする", () => {
-    expect(articleMatchesQuery(BASE, "TYPESCRIPT")).toBe(true);
+    expect(match(BASE, "TYPESCRIPT")).toBe(true);
   });
 
   test("混在ケースでマッチする", () => {
-    expect(articleMatchesQuery(BASE, "TypeScript")).toBe(true);
+    expect(match(BASE, "TypeScript")).toBe(true);
   });
 });
 
-test.describe("articleMatchesQuery — 空白の正規化", () => {
+test.describe("matchesAdvancedQuery — 空白の正規化", () => {
   test("先頭・末尾の空白を無視する", () => {
-    expect(articleMatchesQuery(BASE, "  TypeScript  ")).toBe(true);
+    expect(match(BASE, "  TypeScript  ")).toBe(true);
   });
 
   test("連続空白をスペース1つとして扱う", () => {
-    expect(articleMatchesQuery(BASE, "TypeScript   モナド")).toBe(true);
+    expect(match(BASE, "TypeScript   モナド")).toBe(true);
   });
 });

--- a/src/lib/article-utils.ts
+++ b/src/lib/article-utils.ts
@@ -72,34 +72,6 @@ export function compareByPublishedAtDesc(
 }
 
 /**
- * 記事が検索クエリにマッチするか判定する。
- * スペース区切りで複数ワード AND 検索。
- * title・summary のほか author・categories も対象とする。
- * クエリが空のときは常に true を返す。
- */
-export function articleMatchesQuery(
-  article: {
-    title: string;
-    summary: string;
-    author?: string;
-    categories?: string[];
-  },
-  query: string,
-): boolean {
-  const q = query.trim().toLowerCase();
-  if (!q) return true;
-  const terms = q.split(/\s+/).filter(Boolean);
-  const titleL = article.title.toLowerCase();
-  const summaryL = article.summary.toLowerCase();
-  const authorL = (article.author ?? "").toLowerCase();
-  const categoriesL = (article.categories ?? []).join(" ").toLowerCase();
-  return terms.every(
-    (t) =>
-      titleL.includes(t) || summaryL.includes(t) || authorL.includes(t) || categoriesL.includes(t),
-  );
-}
-
-/**
  * サイクル配列の次の値を返す。
  * 末尾の次は先頭に戻る（ループ）。
  */

--- a/src/lib/release-notes-data.ts
+++ b/src/lib/release-notes-data.ts
@@ -11,6 +11,10 @@ export const RELEASE_NOTES_MARKDOWN = `
 
 - **RSS コンテンツの相対パス画像（avif 等）が 404 になる問題を修正** — Issue #215。フィードの \`content:encoded\` に含まれる相対パス \`<img src="/images/photo.avif">\` が rss.0g0.xyz のパスとして解釈されて 404 になってたのを直したよ〜！\`xml-parser.ts\` の RSS 2.0 / Atom / RDF / JSON Feed すべてのパーサーで \`sanitizeHtml\` のかわりに \`applyCorePipeline(raw, link)\` を呼ぶようにして、記事の URL を baseUrl として相対パスを絶対 URL に解決してからプロキシ経由に書き換えるようになったっ。\`image-mime.ts\` も Sequence AVIF (\`avis\` brand) を \`image/avif\` として認識できるように修正したよっ！💡🖼️
 
+### リファクタリングっ
+
+- **\`articleMatchesQuery\` を廃止して \`matchesAdvancedQuery\` に統合** — Issue #210。\`src/lib/article-utils.ts\` の \`articleMatchesQuery\`（スペース区切り AND 検索のみ対応）は本番コードで既に使われておらず、\`src/lib/article-filter.ts\` が \`matchesAdvancedQuery\`（フィールド指定・OR・否定・フレーズ検索まで対応）に移行済みだったからデッドコードを削除したよ〜！テストも \`matchesAdvancedQuery\` を直接テストするよう書き直して、将来的な乖離リスクをゼロにしたっ✨🧹
+
 ### セキュリティ対策っ
 
 - **DBSC sessionId に UUID 形式検証を追加** — Issue #196。\`challenge\` と \`register\` の両エンドポイントで、クライアント送信の \`sessionId\` に \`../\` や \`%2f\` を含む値を渡しても R2 キーが不正なパスにならないよう UUID フォーマット検証を追加したよ〜！\`/^[0-9a-f]{8}-...-[0-9a-f]{12}$/i\` にマッチしない場合は 400 を返すようになったっ🔒


### PR DESCRIPTION
## Summary

- `src/lib/article-utils.ts` の `articleMatchesQuery` はデッドコードだったため削除
  - 本番コードは既に `src/lib/article-filter.ts` → `matchesAdvancedQuery` に移行済みだった
- `e2e/article-search.spec.ts` のテストを `matchesAdvancedQuery` に書き直し（21テスト全パス）
- リリースノート更新（RELEASE_NOTES.md / release-notes-data.ts）

closes #210

## Test plan

- [x] `npx playwright test e2e/article-search.spec.ts` — 21 tests passed
- [x] `npm run check` — lint/format pass
- [x] pre-commit hooks（typecheck + e2e）通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated search functionality to improve query-matching capabilities and streamline the codebase.
  * Updated end-to-end tests to validate the refactored search behavior, ensuring all existing functionality is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->