### PR TITLE
機能追加: SlideShare スライド埋め込み対応

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # リリースノート 〜ギャルが読み上げるよ〜
 
+## 2026-05-01
+
+### 激アツ新機能っ
+
+- **SlideShare スライド埋め込み対応** — Issue #263。記事本文中の SlideShare リンクが自動で iframe 埋め込みに変換されるようになったよ〜！`slideshare.net/slideshow/{slug}/{id}` 形式の URL を検出して、レスポンシブな 16:9 の埋め込みプレイヤーで表示しちゃう📊✨ フォールバックリンクも付くから安心だよっ🎀 ※ SpeakerDeck の `<script>` 埋め込みは既存の `transformSpeakerDeckScriptEmbeds` で対応済み！リンク URL からは player ID が取れないのでリンク→iframe 変換は対象外だよ〜🎤
+
 ## 2026-04-29
 
 ### パフォーマンス改善っ

--- a/e2e/speakerdeck-embed.spec.ts
+++ b/e2e/speakerdeck-embed.spec.ts
@@ -4,7 +4,10 @@ import {
   processContent,
   collectIframeUrlsFromHtml,
 } from "../src/lib/embed-utils";
-import { transformSpeakerDeckScriptEmbeds } from "../src/lib/html-post-processor";
+import {
+  transformSpeakerDeckScriptEmbeds,
+  transformSlideShareEmbedLinks,
+} from "../src/lib/html-post-processor";
 
 // ── extractEmbedInfo: SpeakerDeck player URL ─────────────────
 
@@ -116,5 +119,100 @@ test.describe("transformSpeakerDeckScriptEmbeds", () => {
     const html = `<script class="speakerdeck-embed" data-id="abc123" data-ratio="1.77" src="//speakerdeck.com/assets/embed.js" />`;
     const result = transformSpeakerDeckScriptEmbeds(html);
     expect(result).toContain("speakerdeck.com/player/abc123");
+  });
+});
+
+// ── SlideShare: extractEmbedInfo ────────────────────────────────
+
+test.describe("extractEmbedInfo — SlideShare", () => {
+  test("embed_code URL を認識する", () => {
+    const info = extractEmbedInfo("https://www.slideshare.net/slideshow/embed_code/287205719");
+    expect(info).not.toBeNull();
+    expect(info!.type).toBe("video");
+    expect(info!.embedUrl).toBe("https://www.slideshare.net/slideshow/embed_code/287205719");
+  });
+
+  test("SlideShare ページ URL は認識しない（embed_code のみ）", () => {
+    const info = extractEmbedInfo("https://www.slideshare.net/slideshow/claude-code/287205719");
+    expect(info).toBeNull();
+  });
+});
+
+// ── SlideShare: transformSlideShareEmbedLinks ───────────────────
+
+test.describe("transformSlideShareEmbedLinks", () => {
+  test("SlideShare リンクを iframe に変換する", () => {
+    const html = `<a href="https://www.slideshare.net/slideshow/claude-code-claude-code-chatgpt-claude-code/287205719">Slides</a>`;
+    const result = transformSlideShareEmbedLinks(html);
+    expect(result).toContain("slideshare.net/slideshow/embed_code/287205719");
+    expect(result).toContain("<iframe");
+    expect(result).toContain("padding-bottom:56.25%");
+  });
+
+  test("フォールバックリンクが生成される", () => {
+    const html = `<a href="https://www.slideshare.net/slideshow/test-slides/12345">Test</a>`;
+    const result = transformSlideShareEmbedLinks(html);
+    expect(result).toContain("SlideShare で見る");
+    expect(result).toContain("slideshare.net/slideshow/test-slides/12345");
+  });
+
+  test("数値 ID がない SlideShare URL は変換しない", () => {
+    const html = `<a href="https://www.slideshare.net/user123/some-deck">Link</a>`;
+    const result = transformSlideShareEmbedLinks(html);
+    expect(result).toBe(html);
+  });
+
+  test("ドット入りスラッグの URL も変換する", () => {
+    const html = `<a href="https://www.slideshare.net/slideshow/node.js-best-practices/55555">Node</a>`;
+    const result = transformSlideShareEmbedLinks(html);
+    expect(result).toContain("slideshare.net/slideshow/embed_code/55555");
+  });
+
+  test("www なしの URL も変換する", () => {
+    const html = `<a href="https://slideshare.net/slideshow/my-talk/99999">Talk</a>`;
+    const result = transformSlideShareEmbedLinks(html);
+    expect(result).toContain("slideshare.net/slideshow/embed_code/99999");
+  });
+
+  test("他のリンクは変換しない", () => {
+    const html = `<a href="https://example.com/slides">Slides</a>`;
+    const result = transformSlideShareEmbedLinks(html);
+    expect(result).toBe(html);
+  });
+
+  test("複数の SlideShare リンクを一括変換する", () => {
+    const html =
+      `<a href="https://www.slideshare.net/slideshow/a/111">A</a>` +
+      `<a href="https://www.slideshare.net/slideshow/b/222">B</a>`;
+    const result = transformSlideShareEmbedLinks(html);
+    expect(result).toContain("embed_code/111");
+    expect(result).toContain("embed_code/222");
+  });
+});
+
+// ── SlideShare: processContent iframe ラッピング ────────────────
+
+test.describe("processContent — SlideShare", () => {
+  test("SlideShare iframe をレスポンシブラッパーで包む", () => {
+    const html = `<iframe src="https://www.slideshare.net/slideshow/embed_code/287205719" width="595" height="485"></iframe>`;
+    const result = processContent(html);
+    expect(result).toContain("position:relative");
+    expect(result).toContain("slideshare.net/slideshow/embed_code/287205719");
+  });
+
+  test("フォールバックリンクが生成される", () => {
+    const html = `<iframe src="https://www.slideshare.net/slideshow/embed_code/12345" width="595" height="485"></iframe>`;
+    const result = processContent(html);
+    expect(result).toContain("SlideShare で見る");
+  });
+});
+
+// ── SlideShare: collectIframeUrlsFromHtml ───────────────────────
+
+test.describe("collectIframeUrlsFromHtml — SlideShare", () => {
+  test("SlideShare embed iframe の src を収集する", () => {
+    const html = `<iframe src="https://www.slideshare.net/slideshow/embed_code/287205719"></iframe>`;
+    const urls = collectIframeUrlsFromHtml(html);
+    expect(urls).toContain("https://www.slideshare.net/slideshow/embed_code/287205719");
   });
 });

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -15,6 +15,7 @@ import {
   transformZennLinkEmbeds,
   transformZennMermaidEmbeds,
   transformSpeakerDeckScriptEmbeds,
+  transformSlideShareEmbedLinks,
   postProcess,
   buildImageSlider,
 } from "./html-post-processor";
@@ -325,6 +326,11 @@ export function extractMainContent(
   // SpeakerDeck の <script class="speakerdeck-embed"> を <iframe> に変換する。
   // preClean で <script> が除去される前に行う必要がある。
   preprocessed = transformSpeakerDeckScriptEmbeds(preprocessed);
+
+  // SlideShare のリンクを iframe 埋め込みに変換する。
+  // Readability が <a> タグを本文外と判定して除去することがあるため、
+  // Readability 実行前に変換しておく。
+  preprocessed = transformSlideShareEmbedLinks(preprocessed);
 
   // Zenn embed (card / tweet / mermaid) は iframe を <p><a> や <pre><code> に変換しておく。
   // Readability は iframe を本文外と判定して span ごと削除することがあるため、

--- a/src/lib/embed-utils.ts
+++ b/src/lib/embed-utils.ts
@@ -78,6 +78,15 @@ export function extractEmbedInfo(url: string): EmbedInfo | null {
       allow: "autoplay; fullscreen; web-share",
     };
 
+  // SlideShare (embed_code URL)
+  const ss = url.match(/slideshare\.net\/slideshow\/embed_code\/(\d+)/);
+  if (ss)
+    return {
+      embedUrl: `https://www.slideshare.net/slideshow/embed_code/${ss[1]}`,
+      type: "video",
+      allow: "autoplay; fullscreen; web-share",
+    };
+
   // Spotify
   const spotify = url.match(
     /open\.spotify\.com\/(track|album|playlist|episode|artist)\/([A-Za-z0-9]+)/,
@@ -132,6 +141,20 @@ export function processContent(html: string, theme: "light" | "dark" = "light"):
     /<iframe([^>]*src=["']https?:\/\/speakerdeck\.com\/player\/([a-f0-9]+)[^"']*["'][^>]*)>([\s\S]*?)<\/iframe>/gi,
     (_match, attrs: string, playerId: string, inner: string) => {
       const fallback = `<a href="https://speakerdeck.com/player/${playerId}" target="_blank" rel="noopener noreferrer" style="display:inline-block;font-size:11px;margin-top:4px;margin-bottom:8px;opacity:0.55">Speaker Deck で見る ↗</a>`;
+      return (
+        `<div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.25em 0;border-radius:8px">` +
+        `<iframe${attrs} style="position:absolute;top:0;left:0;width:100%;height:100%;border:0">${inner}</iframe>` +
+        `</div>` +
+        fallback
+      );
+    },
+  );
+
+  // SlideShare iframe → レスポンシブラッパー
+  result = result.replace(
+    /<iframe([^>]*src=["']https?:\/\/(?:www\.)?slideshare\.net\/slideshow\/embed_code\/(\d+)[^"']*["'][^>]*)>([\s\S]*?)<\/iframe>/gi,
+    (_match, attrs: string, slideId: string, inner: string) => {
+      const fallback = `<a href="https://www.slideshare.net/slideshow/embed_code/${slideId}" target="_blank" rel="noopener noreferrer" style="display:inline-block;font-size:11px;margin-top:4px;margin-bottom:8px;opacity:0.55">SlideShare で見る ↗</a>`;
       return (
         `<div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.25em 0;border-radius:8px">` +
         `<iframe${attrs} style="position:absolute;top:0;left:0;width:100%;height:100%;border:0">${inner}</iframe>` +

--- a/src/lib/html-post-processor.ts
+++ b/src/lib/html-post-processor.ts
@@ -640,6 +640,38 @@ export function transformSpeakerDeckScriptEmbeds(html: string): string {
 }
 
 /**
+ * 記事本文中の SlideShare へのリンクを iframe 埋め込みに変換する。
+ *
+ * ブログ記事はスライドサービスへの URL をそのまま `<a>` で貼っていることが多い。
+ * Readability 通過後もリンクのまま残るため、この関数で iframe に差し替える。
+ *
+ * 対象パターン:
+ * - `<a href="https://www.slideshare.net/slideshow/{slug}/{id}">...</a>`
+ *
+ * SpeakerDeck は `<script class="speakerdeck-embed">` → iframe 変換が
+ * `transformSpeakerDeckScriptEmbeds` で対応済み。リンク URL からは
+ * player ID を取得できないため、リンク→iframe 変換は行わない。
+ */
+export function transformSlideShareEmbedLinks(html: string): string {
+  return html.replace(
+    /<a\b[^>]*\bhref\s*=\s*["'](https?:\/\/(?:www\.)?slideshare\.net\/slideshow\/[^"']+)["'][^>]*>[\s\S]*?<\/a>/gi,
+    (match, url: string) => {
+      const ss = url.match(/slideshare\.net\/slideshow\/[^/"']+\/(\d+)/);
+      if (!ss) return match;
+      const slideId = ss[1];
+      return (
+        `<div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.25em 0;border-radius:8px">` +
+        `<iframe src="https://www.slideshare.net/slideshow/embed_code/${slideId}"` +
+        ` style="position:absolute;top:0;left:0;width:100%;height:100%;border:0"` +
+        ` loading="lazy" allowfullscreen></iframe>` +
+        `</div>` +
+        `<a href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer" style="display:inline-block;font-size:11px;margin-top:4px;margin-bottom:8px;opacity:0.55">SlideShare で見る ↗</a>`
+      );
+    },
+  );
+}
+
+/**
  * 共通後処理パイプライン（画像処理・リンク修正・テーブルラップ・XSS サニタイズ）。
  * postProcess / postProcessMarkdownContent の両方で使用する。
  *

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -182,6 +182,7 @@ export const TRUSTED_IFRAME_RULES: ReadonlyArray<{
   { hosts: ["embed.zenn.studio"] },
   { hosts: ["platform.twitter.com"], pathPrefix: "/embed/" },
   { hosts: ["speakerdeck.com"], pathPrefix: "/player/" },
+  { hosts: ["www.slideshare.net", "slideshare.net"], pathPrefix: "/slideshow/embed_code/" },
 ];
 
 function isTrustedIframeSrc(src: string): boolean {


### PR DESCRIPTION
## Summary
- 記事本文中の SlideShare リンク (`slideshare.net/slideshow/{slug}/{id}`) を自動で iframe 埋め込みに変換
- レスポンシブ 16:9 プレイヤー + フォールバックリンク生成
- `sanitizeHtml` の trusted iframe ルールに SlideShare を追加
- SpeakerDeck の `<script>` 埋め込みは既存の `transformSpeakerDeckScriptEmbeds` で対応済み

Closes #263

## Test plan
- [x] `npx playwright test e2e/speakerdeck-embed.spec.ts` — 26テスト全パス
- [x] `npm run typecheck` — パス
- [x] `npm run check` — パス (lint + format)