### PR TITLE
バグ修正: E2E全テスト実行時の next/headers ESM module resolution エラーを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ a.out
 skills-lock.json
 src/markdown.d.ts
 e2e/_test-import*.spec.ts
+e2e/auth-utils-edge.spec.ts

--- a/e2e/auth-utils.spec.ts
+++ b/e2e/auth-utils.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+import { getJwtExp } from "../src/lib/auth";
+
+test("getJwtExp: 不正なトークンは null を返す", () => {
+  expect(getJwtExp("x.y.z")).toBeNull();
+});
+
+test("getJwtExp: パーツ不足のトークンは null を返す", () => {
+  expect(getJwtExp("onlyonepart")).toBeNull();
+});
+
+test("getJwtExp: 有効な JWT から exp を取得できる", () => {
+  const payload = { sub: "user1", exp: 1234567890 };
+  const encoded = btoa(JSON.stringify(payload)).replace(/=/g, "");
+  const token = `header.${encoded}.signature`;
+  expect(getJwtExp(token)).toBe(1234567890);
+});
+
+test("getJwtExp: exp が数値でない場合は null を返す", () => {
+  const payload = { sub: "user1", exp: "not-a-number" };
+  const encoded = btoa(JSON.stringify(payload)).replace(/=/g, "");
+  const token = `header.${encoded}.signature`;
+  expect(getJwtExp(token)).toBeNull();
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -419,3 +419,17 @@ export async function revokeToken(refreshToken: string): Promise<void> {
     body: JSON.stringify({ refresh_token: refreshToken }),
   });
 }
+
+/** JWT ペイロードの exp クレームを base64 デコードで取得する（署名検証なし） */
+export function getJwtExp(token: string): number | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length < 2) return null;
+    const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/"))) as {
+      exp?: number;
+    };
+    return typeof payload.exp === "number" ? payload.exp : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/server-auth.ts
+++ b/src/lib/server-auth.ts
@@ -1,12 +1,13 @@
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { verifyJwt, refreshTokens, type RefreshResult } from "./auth";
+import { verifyJwt, refreshTokens, getJwtExp, type RefreshResult } from "./auth";
 import { apiError } from "./api-error";
 import { isCsrfViolation } from "./csrf";
 
 // CSRF 判定ロジックは next/* を含まない形でユニットテスト可能にするため `./csrf` に分離している。
 export { isCsrfViolation } from "./csrf";
+export { getJwtExp } from "./auth";
 
 /**
  * CSRF 違反の場合に 403 NextResponse を、合格時は null を返すラッパー。
@@ -163,20 +164,6 @@ export function deduplicatedRefresh(refreshToken: string): Promise<RefreshResult
     });
   inflightRefresh.set(refreshToken, p);
   return p;
-}
-
-/** JWT ペイロードの exp クレームを base64 デコードで取得する（署名検証なし） */
-export function getJwtExp(token: string): number | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length < 2) return null;
-    const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/"))) as {
-      exp?: number;
-    };
-    return typeof payload.exp === "number" ? payload.exp : null;
-  } catch {
-    return null;
-  }
 }
 
 /** BETA_ALLOWED_SUBS が設定されている場合、sub がリストに含まれるか確認 */


### PR DESCRIPTION
## Summary

- `getJwtExp` を `server-auth.ts`（`next/headers` 依存）から `auth.ts`（`next/*` 非依存）に移動
- E2Eテストファイルの import 先を `auth.ts` に変更し、ESM module resolution エラーを解消
- 診断用テストファイル（`_test-import*.spec.ts`）を正式なユニットテスト（`auth-utils.spec.ts`）に置き換え

## 原因

`e2e/_test-import.spec.ts` が `server-auth.ts` を直接 import → `next/headers`（CommonJS）が ESM として解決される → Playwright 全テスト実行時にのみ失敗（個別実行では当該ファイルが読まれない）

## Test plan

- [x] `npx playwright test`（全テスト）で dev サーバー起動・1281テスト全パスを確認
- [x] `npx playwright test e2e/auth-utils.spec.ts` で新テスト4件パス確認
- [x] `npm run check` + `npm run typecheck` パス
- [x] pre-commit フック（oxlint + tsc + e2e）パス

Closes #267