### PR TITLE
AI 自走サイクル: 監査由来 6 Issue 一括対応 (#1132〜#1137)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -827,7 +827,7 @@ const match = matchesKeywordFilter(article, compiledFilter);
 
 ## src/lib/ 層設計 (`src/lib/`)
 
-`src/lib/` には 141 ファイル の純粋関数 / ヘルパー / ラッパーが配置される。Workers + ブラウザ両環境で再利用される基盤レイヤーとして責務境界を明確にするため、以下の **機能別グループ + 採用すべき canonical pattern** に従う。
+`src/lib/` には 140 ファイル の純粋関数 / ヘルパー / ラッパーが配置される。Workers + ブラウザ両環境で再利用される基盤レイヤーとして責務境界を明確にするため、以下の **機能別グループ + 採用すべき canonical pattern** に従う。
 
 ### グループ分類
 

--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -606,6 +606,7 @@ function ArticleList({
 
   const { resolveItemProps } = useArticleListItemProps({
     feedMap,
+    articles: filtered,
     readIds,
     readBeforeTimestamp,
     bookmarkIds,

--- a/src/components/SaveUrlModal.tsx
+++ b/src/components/SaveUrlModal.tsx
@@ -32,6 +32,9 @@ export default function SaveUrlModal({ url, onUrlChange, saving, error, onSave, 
           onChange={(e) => onUrlChange(e.target.value)}
           disabled={saving}
           autoFocus
+          aria-required
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? "save-url-error" : undefined}
           className="w-full text-[13px] bg-surface-base border border-border-default rounded-lg px-3 py-2 text-text-strong placeholder-text-faint outline-none focus:border-text-muted transition-colors duration-200"
         />
 
@@ -65,7 +68,7 @@ export default function SaveUrlModal({ url, onUrlChange, saving, error, onSave, 
         </div>
 
         {error && (
-          <p role="alert" className="mt-2 text-[12px] text-error">
+          <p id="save-url-error" role="alert" className="mt-2 text-[12px] text-error">
             {error}
           </p>
         )}

--- a/src/components/SnoozeModal.tsx
+++ b/src/components/SnoozeModal.tsx
@@ -126,8 +126,17 @@ export default function SnoozeModal({ articleTitle, onSnooze, onClose, returnFoc
             value={customDateTime}
             min={minDateTime}
             onChange={(e) => setCustomDateTime(e.target.value)}
+            aria-invalid={customDateTime !== "" && !customValid}
+            aria-describedby={
+              customDateTime !== "" && !customValid ? "snooze-custom-error" : undefined
+            }
             className="w-full px-2 py-1.5 text-[13px] bg-surface-subtle text-text-strong border border-border-default rounded-md focus:outline-none focus:border-ink"
           />
+          {customDateTime !== "" && !customValid && (
+            <p id="snooze-custom-error" role="alert" className="text-[11px] text-error">
+              過去の日時は指定できません
+            </p>
+          )}
           <button
             type="button"
             onClick={() => {
@@ -136,6 +145,9 @@ export default function SnoozeModal({ articleTitle, onSnooze, onClose, returnFoc
               onClose();
             }}
             disabled={!customValid}
+            aria-describedby={
+              customDateTime !== "" && !customValid ? "snooze-custom-error" : undefined
+            }
             className="w-full px-3 py-1.5 max-md:min-h-[44px] lg:min-h-[24px] text-[12px] bg-ink text-ink-text rounded-md hover:bg-ink-hover disabled:bg-surface-subtle disabled:text-text-faint transition-colors"
           >
             この日時までスヌーズ

--- a/src/components/article-items/shared.tsx
+++ b/src/components/article-items/shared.tsx
@@ -16,6 +16,12 @@ import { buildImageProxyUrl } from "../../lib/image-proxy-url";
 // ── 共通キーボードハンドラ ──────────────────────────────────────────────
 
 /**
+ * 内部 helper: `useArticleHandlers` 経由で参照する。
+ * 子コンポーネント (CompactItem / ListItem / CardItem / MagazineItem) から直接 import せず、
+ * 必ず `useArticleHandlers` hook 経由で利用すること。pure handler の独立 export は
+ * `useArticleHandlers` 内部での再利用 + 将来の sibling component 拡張時の retain 用途で、
+ * 外部 caller を想定していない。
+ *
  * Enter / Space で記事を選択する共通 onKeyDown ハンドラを生成する。
  * React の KeyboardEvent / MouseEvent は DOM global と同名なので、本 file 内では
  * React 由来の event 型と区別するため呼び出し側 (ListItem 等) で receive される。
@@ -35,6 +41,12 @@ export function handleArticleKeyDown<T = Element>(
 }
 
 /**
+ * 内部 helper: `useArticleHandlers` 経由で参照する。
+ * 子コンポーネント (CompactItem / ListItem / CardItem / MagazineItem) から直接 import せず、
+ * 必ず `useArticleHandlers` hook 経由で利用すること。pure handler の独立 export は
+ * `useArticleHandlers` 内部での再利用 + 将来の sibling component 拡張時の retain 用途で、
+ * 外部 caller を想定していない。
+ *
  * 右クリック (contextmenu) で記事メニューを開く共通ハンドラを生成する。
  * onContextMenu 未設定時 (= 親が menu 未対応) は no-op で event 伝播を許可。
  * ListItem / MagazineItem / CardItem の同形 useCallback 重複を集約。

--- a/src/hooks/useArticleListItemProps.test.ts
+++ b/src/hooks/useArticleListItemProps.test.ts
@@ -57,6 +57,7 @@ interface SetupParams {
 function defaultParams(overrides: SetupParams = {}) {
   return {
     feedMap: new Map<string, Feed>([["feed-1", makeFeed()]]),
+    articles: [makeArticle()],
     readIds: overrides.readIds ?? new Set<string>(),
     readBeforeTimestamp: null,
     bookmarkIds: overrides.bookmarkIds ?? new Set<string>(),

--- a/src/hooks/useArticleListItemProps.ts
+++ b/src/hooks/useArticleListItemProps.ts
@@ -18,6 +18,11 @@ import { useSyncedRef } from "./useSyncedRef";
  */
 interface Params {
   feedMap: Map<string, Feed>;
+  /**
+   * フィルタ済み記事配列 (#1134): 読書進捗の per-item localStorage hit を
+   * Map<id, progress> 1 回構築に集約するため hook 側で受け取る。
+   */
+  articles: Article[];
   readIds: Set<string>;
   readBeforeTimestamp: string | null;
   bookmarkIds: Set<string>;
@@ -49,6 +54,7 @@ interface Params {
  */
 export function useArticleListItemProps({
   feedMap,
+  articles,
   readIds,
   readBeforeTimestamp,
   bookmarkIds,
@@ -88,12 +94,24 @@ export function useArticleListItemProps({
     [readBeforeTimestamp],
   );
 
+  // #1134: 読書進捗を articles 配列単位で Map に集約。per-row resolveItemProps 呼出での
+  // localStorage.getItem + JSON.parse を articles 変化時の 1 回構築に縮約。
+  // j/k 高速操作で identity churn しても loadProgress は再走査されない。
+  const progressMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const a of articles) {
+      const p = loadProgress(a.id)?.progress;
+      if (p != null) map.set(a.id, p);
+    }
+    return map;
+  }, [articles]);
+
   const resolveItemProps = useCallback(
     (article: Article, index: number, isDeleting?: boolean, isNew?: boolean): ArticleItemProps => {
       const feed = feedMap.get(article.feedHash);
-      // #932: 途中まで読んだ記事 (5〜95%) のみ進捗バー表示用に値を渡す。
-      // visible 分のみ呼ばれる + localStorage getItem は高速なため per-item read で十分。
-      const rawProgress = loadProgress(article.id)?.progress;
+      // #932 / #1134: 途中まで読んだ記事 (5〜95%) のみ進捗バー表示用に値を渡す。
+      // progressMap は articles 単位で構築済 (per-row localStorage hit 回避)。
+      const rawProgress = progressMap.get(article.id);
       const readingProgress =
         rawProgress != null && rawProgress > 0.05 && rawProgress < 0.95 ? rawProgress : null;
       return {
@@ -124,6 +142,7 @@ export function useArticleListItemProps({
     [
       readBeforeMs,
       feedMap,
+      progressMap,
       ogpCacheRef,
       showFeedName,
       query,

--- a/src/hooks/useFilteredArticles.ts
+++ b/src/hooks/useFilteredArticles.ts
@@ -3,7 +3,7 @@ import type { Article, Feed, FeedView, KeywordFilter } from "../types";
 import { SPECIAL_FEED_IDS } from "../lib/storage";
 import { useGracePeriod } from "./useGracePeriod";
 import { filterByStructure, applyStateFilterAndSort } from "../lib/article-filter";
-import { createReadingTimeCache } from "../lib/article-utils";
+import { createReadingTimeCache, getArticleTimestamp } from "../lib/article-utils";
 import { buildFilterMap, normalizeFilter, type CompiledKeywordFilter } from "../lib/keyword-filter";
 import {
   equalDigestLimitMap,
@@ -412,8 +412,9 @@ export function useFilteredArticles({
     }
 
     // perf #930: filtered 全件の timestamp を事前計算して比較ループ内の Date.parse 再呼出を省く
+    // fallback-derivation.md: sibling 純粋関数の fallback chain は canonical helper を経由して揃える
     const tsCache = new Map<string, number>(
-      filtered.map((a) => [a.id, Date.parse(a.publishedAt ?? a.createdAt ?? "")]),
+      filtered.map((a) => [a.id, Date.parse(getArticleTimestamp(a))]),
     );
 
     // link → 同一リンクを持つ記事グループ（1 パスで構築）

--- a/src/hooks/usePrefetchGalleryContents.ts
+++ b/src/hooks/usePrefetchGalleryContents.ts
@@ -340,5 +340,12 @@ export function usePrefetchGalleryContents({
     })();
   }, []);
 
-  return { media, failedIds, expandingIds, retryArticle, rateLimitedUntil };
+  // react-state-ref.md「複数 state を return する hook は戻り値全体を useMemo で wrap」:
+  // 戻り値は ArticleList で field destructure された後、galleryCtxValue (`ArticleList.tsx`)
+  // の useMemo に流れ込んで Provider value の identity を制御する。useMemo wrap で
+  // state 変化時のみ identity 更新に絞り、Gallery card consumer の不要 re-render を防ぐ。
+  return useMemo(
+    () => ({ media, failedIds, expandingIds, retryArticle, rateLimitedUntil }),
+    [media, failedIds, expandingIds, retryArticle, rateLimitedUntil],
+  );
 }


### PR DESCRIPTION
> 🤖 **AI 投稿 (Claude Code)** — rss-issue-sprint サイクルで AI 自走 5 条件全充足の 6 Issue を sequential commit で実装。

## 対応 Issue

| Issue | 種別 | 内容 | touch |
| ----- | ---- | ---- | ----- |
| #1137 | docs | architecture.md src/lib/ file count drift 修正 (141 → 140) | 1 |
| #1133 | refactor | useFilteredArticles を canonical `getArticleTimestamp` に統合 | 1 |
| #1136 | refactor | article-items shared.tsx 内部 helper export 意図 JSDoc 明示 (案 B 現状維持系) | 1 |
| #1132 | a11y | SaveUrlModal / SnoozeModal の aria error wiring を canonical 揃え | 2 |
| #1135 | perf | usePrefetchGalleryContents 戻り値の useMemo wrap で identity 安定化 | 1 |
| #1134 | perf | useArticleListItemProps の loadProgress を articles 単位 Map に集約 | 3 |

各 Issue を 1 commit で完結、`closes #N` で自動クローズ。

## 検証

- `npm run typecheck` pass
- `npm run check` errors 0 件 (pre-existing warnings 10 件は本変更外)
- `npm run test:unit` 292/292 pass
- 全件 AI 自走 5 条件全充足 (touch ≤ 5 / 機能変化なし or 既存挙動互換 / 推奨案明示済 / 復元可能)
- 機能 regression は構造的に発生しない (fallback chain canonical 統合 / Map 集約 / JSDoc 追加 / aria 属性追加 / docs 1 行修正)

## Test plan

- [ ] e2e で記事一覧表示・スヌーズモーダル・URL 保存モーダルの基本動作確認
- [ ] j/k スクロール時の jank 体感確認 (#1134)
- [ ] Gallery card の re-render 頻度確認 (#1135)
- [ ] スクリーンリーダーでの error メッセージ読み上げ確認 (#1132)

https://claude.ai/code/session_017jnKPDxmf5wvk8aCL5JXgy

---
_Generated by [Claude Code](https://claude.ai/code/session_017jnKPDxmf5wvk8aCL5JXgy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced save URL and snooze modals with improved screen reader support, including error announcements, validation states, and required field indicators.
  * Added accessible error notifications for invalid date/time inputs in snooze modal with clear user feedback.

* **Performance**
  * Optimized gallery content prefetching logic to reduce unnecessary component re-renders and improve overall responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->